### PR TITLE
ignore release output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 nomad-driver-podman
+pkg/


### PR DESCRIPTION
ignores `pkg/` which is added during build time by release tool