### PR TITLE
allow passed in network namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * config: Add ability to configure container network_mode [[GH-33](https://github.com/hashicorp/nomad-driver-podman/issues/33)]
+* network: (Consul Connect) Ability to accept a bridge network namespace from Nomad. [[GH-38](https://github.com/hashicorp/nomad-driver-podman/issues/38)]
 
 ## 0.0.2 (June 11, 2020)
 

--- a/driver.go
+++ b/driver.go
@@ -65,6 +65,12 @@ var (
 		SendSignals: false,
 		Exec:        false,
 		FSIsolation: drivers.FSIsolationNone,
+		NetIsolationModes: []drivers.NetIsolationMode{
+			drivers.NetIsolationModeGroup,
+			drivers.NetIsolationModeHost,
+			drivers.NetIsolationModeTask,
+		},
+		MustInitiateNetwork: false,
 	}
 )
 
@@ -370,6 +376,15 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		swap = driverConfig.MemorySwap
 	}
 
+	// Generate network string
+	var network string
+	if cfg.NetworkIsolation != nil &&
+		cfg.NetworkIsolation.Path != "" {
+		network = fmt.Sprintf("ns:%s", cfg.NetworkIsolation.Path)
+	} else {
+		network = driverConfig.NetworkMode
+	}
+
 	createOpts := iopodman.Create{
 		Args:              allArgs,
 		Env:               &allEnv,
@@ -385,7 +400,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		MemoryReservation: &driverConfig.MemoryReservation,
 		MemorySwap:        &swap,
 		MemorySwappiness:  &driverConfig.MemorySwappiness,
-		Network:           &driverConfig.NetworkMode,
+		Network:           &network,
 		Tmpfs:             &driverConfig.Tmpfs,
 	}
 


### PR DESCRIPTION
pr allows running connect job through docker network namespace

```hcl
job "countdash" {
  datacenters = ["dc1"]

  group "api" {
    network {
      mode = "bridge"
    }

    service {
      name = "count-api"
      port = "9001"

      connect {
        sidecar_service {}
      }
    }

    task "web" {
      driver = "podman"

      config {
        image = "hashicorpnomad/counter-api:v1"
      }
    }
  }

  group "dashboard" {
    network {
      mode = "bridge"

      port "http" {
        static = 9002
        to     = 9002
      }
    }

    service {
      name = "count-dashboard"
      port = "9002"

      connect {
        sidecar_service {
          proxy {
            upstreams {
              destination_name = "count-api"
              local_bind_port  = 8081
            }
          }
        }
      }
    }

    task "dashboard" {
      driver = "podman"

      env {
        COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_count_api}"
      }

      config {
        image = "hashicorpnomad/counter-dashboard:v1"
      }
    }
  }
}
```

podman.hcl

```
plugin_dir = "/opt/nomad/plugins"
bind_addr  = "192.168.1.54"
client {
  enabled               = true
}

plugin "nomad-driver-podman" {
  config {
    volumes {
      enabled = true
    }
  }
}

```

`sudo env PATH=$PATH nomad agent -dev-connect -config=podman.hcl`
`consul agent -dev -advertise="192.168.1.54"`