### PR TITLE
Weeezes rootless + changes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,6 +8,8 @@ changelogfmt:
 check: ## Lint the source code
 	@echo "==> Linting source code..."
 	@golangci-lint run
+	@echo "==> vetting hc-log statements"
+	@hclogvet .
 
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies
@@ -15,3 +17,4 @@ lint-deps: ## Install linter dependencies
 	@echo "==> Updating linter dependencies..."
 	GO111MODULE=on cd tools && go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 	GO111MODULE=on cd tools && go get github.com/client9/misspell/cmd/misspell@v0.3.4
+	GO111MODULE=on cd tools && go get github.com/hashicorp/go-hclog/hclogvet@master 

--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@ this plugin to Nomad!
 
 ## Features
 
-* use the jobs driver config to define the image for your container
-* start/stop containers with default or customer entrypoint and arguments
+* Use the jobs driver config to define the image for your container
+* Start/stop containers with default or customer entrypoint and arguments
 * [Nomad runtime environment](https://www.nomadproject.io/docs/runtime/environment.html) is populated
-* use nomad alloc data in the container.
-* bind mount custom volumes into the container
-* publish ports
-* monitor the memory consumption
-* monitor CPU usage
-* task config cpu value is used to populate podman CpuShares
-* Container log is forwarded to [Nomad logger](https://www.nomadproject.io/docs/commands/alloc/logs.html) 
-* utilize podmans --init feature
-* set username or UID used for the specified command within the container (podman --user option).
-* fine tune memory usage: standard [nomad memory resource](https://www.nomadproject.io/docs/job-specification/resources.html#memory) plus additional driver specific swap, swappiness and reservation parameters, OOM handling
+* Use nomad alloc data in the container.
+* Bind mount custom volumes into the container
+* Publish ports
+* Monitor the memory consumption
+* Monitor CPU usage
+* Task config cpu value is used to populate podman CpuShares
+* Container log is forwarded to [Nomad logger](https://www.nomadproject.io/docs/commands/alloc/logs.html)
+* Utilize podmans --init feature
+* Set username or UID used for the specified command within the container (podman --user option).
+* Fine tune memory usage: standard [nomad memory resource](https://www.nomadproject.io/docs/job-specification/resources.html#memory) plus additional driver specific swap, swappiness and reservation parameters, OOM handling
+* Supports rootless containers with cgroup V2
 
 
 ## Building The Driver from source
@@ -44,11 +45,12 @@ cd nomad-driver-podman
 
 - [Nomad](https://www.nomadproject.io/downloads.html) 0.9+
 - Linux host with `podman` installed
+- For rootless containers you need a system supporting cgroup V2 and a few other things, follow [this tutorial](https://github.com/containers/libpod/blob/master/docs/tutorials/rootless_tutorial.md)
 
 You need a varlink enabled podman binary and a system socket activation unit,
-see https://podman.io/blogs/2019/01/16/podman-varlink.html. 
+see https://podman.io/blogs/2019/01/16/podman-varlink.html.
 
-nomad agent, nomad-driver-podman and podman will reside on the same host, so you 
+nomad agent, nomad-driver-podman and podman will reside on the same host, so you
 do not have to worry about the ssh aspects of podman varlink.
 
 Ensure that nomad can find the plugin, see [plugin_dir](https://www.nomadproject.io/docs/configuration/index.html#plugin_dir)
@@ -57,7 +59,7 @@ Ensure that nomad can find the plugin, see [plugin_dir](https://www.nomadproject
 
 * volumes stanza:
 
-  * enabled - Defaults to true. Allows tasks to bind host paths (volumes) inside their container. 
+  * enabled - Defaults to true. Allows tasks to bind host paths (volumes) inside their container.
   * selinuxlabel - Allows the operator to set a SELinux label to the allocation and task local bind-mounts to containers. If used with _volumes.enabled_ set to false, the labels will still be applied to the standard binds in the container.
 
 ```
@@ -85,8 +87,8 @@ plugin "nomad-driver-podman" {
 }
 ```
 
-* recover_stopped (bool) Defaults to true. Allows the driver to start and resuse a previously stopped container after 
-  a Nomad client restart. 
+* recover_stopped (bool) Defaults to true. Allows the driver to start and resuse a previously stopped container after
+  a Nomad client restart.
   Consider a simple single node system and a complete reboot. All previously managed containers
   will be reused instead of disposed and recreated.
 
@@ -98,13 +100,31 @@ plugin "nomad-driver-podman" {
 }
 ```
 
+* socket_path (string) Defaults to `"unix://run/podman/io.podman"` when running as root or a cgroup V1 system, and `"unix://run/user/<USER_ID>/podman/io.podman"` for rootless cgroup V2 systems
+
+
+```
+plugin "nomad-driver-podman" {
+  config {
+    socket_path = "unix://run/podman/io.podman"
+  }
+}
+```
 ## Task Configuration
 
-* **image** - The image to run, 
+* **image** - The image to run,
 
 ```
 config {
   image = "docker://redis"
+}
+```
+
+* **entrypoint** - (Optional) The entrypoint for the container. Defaults to the entrypoint set in the image.
+
+```
+config {
+  entrypoint = "/entrypoint.sh"
 }
 ```
 
@@ -127,7 +147,15 @@ config {
 }
 ```
 
-* **volumes** - (Optional) A list of host_path:container_path strings to bind host paths to container paths. 
+* **working_dir** - (Optional) The working directory for the container. Defaults to the default set in the image.
+
+```
+config {
+  working_dir = "/data"
+}
+```
+
+* **volumes** - (Optional) A list of host_path:container_path strings to bind host paths to container paths.
 
 ```
 config {
@@ -137,7 +165,7 @@ config {
 }
 ```
 
-* **tmpfs** - (Optional) A list of /container_path strings for tmpfs mount points. See podman run --tmpfs options for details. 
+* **tmpfs** - (Optional) A list of /container_path strings for tmpfs mount points. See podman run --tmpfs options for details.
 
 ```
 config {
@@ -188,7 +216,7 @@ config {
 }
 ```
 
-* **memory_swap** - A limit value equal to memory plus swap. The swap LIMIT should always be larger than the [memory value](https://www.nomadproject.io/docs/job-specification/resources.html#memory). 
+* **memory_swap** - A limit value equal to memory plus swap. The swap LIMIT should always be larger than the [memory value](https://www.nomadproject.io/docs/job-specification/resources.html#memory).
 
 Unit can be b (bytes), k (kilobytes), m (megabytes), or g (gigabytes). If you don't specify a unit, b is used. Set LIMIT to -1 to enable unlimited swap.
 
@@ -266,6 +294,6 @@ nomad run redis.nomad
 
 podman ps
 
-CONTAINER ID  IMAGE                           COMMAND               CREATED         STATUS             PORTS  NAMES                                                                              
+CONTAINER ID  IMAGE                           COMMAND               CREATED         STATUS             PORTS  NAMES
 6d2d700cbce6  docker.io/library/redis:latest  docker-entrypoint...  16 seconds ago  Up 16 seconds ago         redis-60fdc69b-65cb-8ece-8554-df49321b3462
 ```

--- a/client.go
+++ b/client.go
@@ -43,6 +43,8 @@ type PodmanClient struct {
 
 	// logger will log to the Nomad agent
 	logger hclog.Logger
+
+	varlinkSocketPath string
 }
 
 // withVarlink calls a podman varlink function and retries N times in case of network failures
@@ -223,7 +225,6 @@ func (c *PodmanClient) InspectContainer(containerID string) (iopodman.InspectCon
 
 // getConnection opens a new varlink connection
 func (c *PodmanClient) getConnection() (*varlink.Connection, error) {
-	// FIXME: a parameter for the socket would be nice
-	varlinkConnection, err := varlink.NewConnection(c.ctx, "unix://run/podman/io.podman")
+	varlinkConnection, err := varlink.NewConnection(c.ctx, c.varlinkSocketPath)
 	return varlinkConnection, err
 }

--- a/client.go
+++ b/client.go
@@ -227,6 +227,25 @@ func (c *PodmanClient) InspectContainer(containerID string) (iopodman.InspectCon
 	return ret, err
 }
 
+// InspectImage data takes a name or ID of an image and returns the inspection
+// data as iopodman.InspectImageData.
+func (c *PodmanClient) InspectImage(imageID string) (iopodman.InspectImageData, error) {
+	var ret iopodman.InspectImageData
+	c.logger.Debug("Inspect image", "image", imageID)
+	err := c.withVarlink(func(varlinkConnection *varlink.Connection) error {
+		inspectJSON, err := iopodman.InspectImage().Call(c.ctx, varlinkConnection, imageID)
+		if err == nil {
+			err = json.Unmarshal([]byte(inspectJSON), &ret)
+			if err != nil {
+				c.logger.Error("failed to unmarshal inspect image", "err", err)
+				return err
+			}
+
+		}
+		return err
+	})
+	return ret, err
+}
 
 func guessSocketPath(user *user.User, procFilesystems []string) string {
 	rootVarlinkPath := "unix://run/podman/io.podman"

--- a/client.go
+++ b/client.go
@@ -227,6 +227,26 @@ func (c *PodmanClient) InspectContainer(containerID string) (iopodman.InspectCon
 	return ret, err
 }
 
+// PullImage takes a name or ID of an image and pulls it to local storage
+// returning the name of the image pulled
+func (c *PodmanClient) PullImage(imageID string) (string, error) {
+	var ret string
+	c.logger.Debug("Pull image", "image", imageID)
+	err := c.withVarlink(func(varlinkConnection *varlink.Connection) error {
+		moreResponse, err := iopodman.PullImage().Call(c.ctx, varlinkConnection, imageID)
+		if err == nil {
+			ret = moreResponse.Logs[len(moreResponse.Logs)-1]
+			if err != nil {
+				c.logger.Error("failed to unmarshal image pull logs", "err", err)
+				return err
+			}
+
+		}
+		return err
+	})
+	return ret, err
+}
+
 // InspectImage data takes a name or ID of an image and returns the inspection
 // data as iopodman.InspectImageData.
 func (c *PodmanClient) InspectImage(imageID string) (iopodman.InspectImageData, error) {

--- a/client.go
+++ b/client.go
@@ -22,8 +22,12 @@ import (
 	"github.com/hashicorp/nomad-driver-podman/iopodman"
 	"github.com/varlink/go/varlink"
 
+	"os"
+	"bufio"
+	"os/user"
 	"context"
 	"encoding/json"
+	"strings"
 	"fmt"
 	"net"
 	"time"
@@ -221,6 +225,49 @@ func (c *PodmanClient) InspectContainer(containerID string) (iopodman.InspectCon
 		return err
 	})
 	return ret, err
+}
+
+
+func guessSocketPath(user *user.User, procFilesystems []string) string {
+	rootVarlinkPath := "unix://run/podman/io.podman"
+	if user.Uid == "0" {
+		return rootVarlinkPath
+	}
+
+	cgroupv2 := isCGroupV2(procFilesystems)
+
+	if cgroupv2 {
+		return fmt.Sprintf("unix://run/user/%s/podman/io.podman", user.Uid)
+	}
+
+	return rootVarlinkPath
+}
+
+func isCGroupV2(procFilesystems []string) bool {
+	cgroupv2 := false
+	for _,l := range procFilesystems {
+		if strings.HasSuffix(l, "cgroup2") {
+			cgroupv2 = true
+		}
+	}
+
+	return cgroupv2
+}
+
+func getProcFilesystems() ([]string, error) {
+	file, err := os.Open("/proc/filesystems")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	return lines, scanner.Err()
 }
 
 // getConnection opens a new varlink connection

--- a/client.go
+++ b/client.go
@@ -22,14 +22,14 @@ import (
 	"github.com/hashicorp/nomad-driver-podman/iopodman"
 	"github.com/varlink/go/varlink"
 
-	"os"
 	"bufio"
-	"os/user"
 	"context"
 	"encoding/json"
-	"strings"
 	"fmt"
 	"net"
+	"os"
+	"os/user"
+	"strings"
 	"time"
 )
 
@@ -284,7 +284,7 @@ func guessSocketPath(user *user.User, procFilesystems []string) string {
 
 func isCGroupV2(procFilesystems []string) bool {
 	cgroupv2 := false
-	for _,l := range procFilesystems {
+	for _, l := range procFilesystems {
 		if strings.HasSuffix(l, "cgroup2") {
 			cgroupv2 = true
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 Thomas Weber
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os/user"
+	"testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_GuessSocketPathForRootCgroupV1(t *testing.T) {
+	u := user.User { Uid: "0" }
+	fs := []string{"nodev	cgroup"}
+	p := guessSocketPath(&u, fs)
+
+	require.Equal(t, p, "unix://run/podman/io.podman")
+}
+
+func TestClient_GuessSocketPathForRootCgroupV2(t *testing.T) {
+	u := user.User { Uid: "0" }
+	fs := []string{"nodev	cgroup2"}
+	p := guessSocketPath(&u, fs)
+
+	require.Equal(t, p, "unix://run/podman/io.podman")
+}
+
+func TestClient_GuessSocketPathForUserCgroupV1(t *testing.T) {
+	u := user.User { Uid: "1000" }
+	fs := []string{"nodev	cgroup"}
+	p := guessSocketPath(&u, fs)
+
+	require.Equal(t, p, "unix://run/podman/io.podman")
+}
+
+func TestClient_GuessSocketPathForUserCgroupV2_1(t *testing.T) {
+	u := user.User { Uid: "1000" }
+	fs := []string{"nodev	cgroup2"}
+	p := guessSocketPath(&u, fs)
+
+	require.Equal(t, p, "unix://run/user/1000/podman/io.podman")
+}
+
+func TestClient_GuessSocketPathForUserCgroupV2_2(t *testing.T) {
+	u := user.User { Uid: "1337" }
+	fs := []string{"nodev	cgroup2"}
+	p := guessSocketPath(&u, fs)
+
+	require.Equal(t, p, "unix://run/user/1337/podman/io.podman")
+}
+
+func TestClient_GetProcFilesystems(t *testing.T) {
+	procFilesystems, err := getProcFilesystems()
+
+	require.NoError(t, err)
+	require.Greater(t, len(procFilesystems), 0)
+}

--- a/config.go
+++ b/config.go
@@ -49,10 +49,7 @@ var (
 			hclspec.NewLiteral("true"),
 		),
 		// the path to the VarLink socket
-		"socket_path": hclspec.NewDefault(
-			hclspec.NewAttr("socket_path", "string", false),
-			hclspec.NewLiteral(`"unix://run/podman/io.podman"`),
-		),
+		"socket_path": hclspec.NewAttr("socket_path", "string", false),
 	})
 
 	// taskConfigSpec is the hcl specification for the driver config section of

--- a/config.go
+++ b/config.go
@@ -57,6 +57,8 @@ var (
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		"args":               hclspec.NewAttr("args", "list(string)", false),
 		"command":            hclspec.NewAttr("command", "string", false),
+		"entrypoint":         hclspec.NewAttr("entrypoint", "string", false),
+		"working_dir":        hclspec.NewAttr("working_dir", "string", false),
 		"hostname":           hclspec.NewAttr("hostname", "string", false),
 		"image":              hclspec.NewAttr("image", "string", true),
 		"init":               hclspec.NewAttr("init", "bool", false),
@@ -92,8 +94,10 @@ type PluginConfig struct {
 
 // TaskConfig is the driver configuration of a task within a job
 type TaskConfig struct {
-	Args              []string           `codec:"args"`
 	Command           string             `codec:"command"`
+	Entrypoint        string             `codec:"entrypoint"`
+	Args              []string           `codec:"args"`
+	WorkingDir        string             `codec:"working_dir"`
 	Hostname          string             `codec:"hostname"`
 	Image             string             `codec:"image"`
 	Init              bool               `codec:"init"`

--- a/config.go
+++ b/config.go
@@ -48,6 +48,11 @@ var (
 			hclspec.NewAttr("recover_stopped", "bool", false),
 			hclspec.NewLiteral("true"),
 		),
+		// the path to the VarLink socket
+		"socket_path": hclspec.NewDefault(
+			hclspec.NewAttr("socket_path", "string", false),
+			hclspec.NewLiteral(`"unix://run/podman/io.podman"`),
+		),
 	})
 
 	// taskConfigSpec is the hcl specification for the driver config section of
@@ -85,6 +90,7 @@ type PluginConfig struct {
 	Volumes        VolumeConfig `codec:"volumes"`
 	GC             GCConfig     `codec:"gc"`
 	RecoverStopped bool         `codec:"recover_stopped"`
+	SocketPath     string       `codec:"socket_path"`
 }
 
 // TaskConfig is the driver configuration of a task within a job

--- a/driver.go
+++ b/driver.go
@@ -160,6 +160,8 @@ func (d *Driver) SetConfig(cfg *base.Config) error {
 		d.nomadConfig = cfg.AgentConfig.Driver
 	}
 
+	d.podmanClient.varlinkSocketPath = config.SocketPath
+
 	return nil
 }
 

--- a/driver.go
+++ b/driver.go
@@ -422,14 +422,17 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 
 	d.logger.Debug("Volumes", fmt.Sprintf("%#v", allVolumes))
 
-	// reset env so we don't inherit host env by default
-	cfg.Env = make(map[string]string)
 	// ensure to include port_map into tasks environment map
 	cfg.Env = taskenv.SetPortMapEnvs(cfg.Env, driverConfig.PortMap)
 	// Set the env to image defaults
-	allEnv := img.Config.Env
-	// convert environment map into a k=v list
-	allEnv = append(allEnv, cfg.EnvList()...)
+	for _,v := range img.Config.Env {
+		p := strings.Split(v, "=")
+		cfg.Env[p[0]] = p[1]
+	}
+	allEnv := []string{}
+	for k,v := range cfg.Env {
+		allEnv = append(allEnv, fmt.Sprintf("%s=%s", k, v))
+	}
 	d.logger.Debug("Env", fmt.Sprintf("%#v", allEnv))
 
 	// Apply SELinux Label to each volume

--- a/driver.go
+++ b/driver.go
@@ -431,7 +431,6 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	for k, v := range cfg.Env {
 		allEnv = append(allEnv, fmt.Sprintf("%s=%s", k, v))
 	}
-	d.logger.Debug("Env", fmt.Sprintf("%#v", allEnv))
 
 	// Apply SELinux Label to each volume
 	if selinuxLabel := d.config.Volumes.SelinuxLabel; selinuxLabel != "" {

--- a/driver.go
+++ b/driver.go
@@ -394,7 +394,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	if err != nil {
 		return nil, nil, err
 	}
-	d.logger.Trace("binding volumes", "volumes", allVolumes)
+	d.logger.Debug("binding volumes", "volumes", allVolumes)
 
 	swap := memoryLimit
 	if driverConfig.MemorySwap != "" {

--- a/driver.go
+++ b/driver.go
@@ -347,7 +347,6 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("failed to decode driver config: %v", err)
 	}
 
-	// d.logger.Info("starting podman task", "driver_cfg", hclog.Fmt("%+v", driverConfig))
 	handle := drivers.NewTaskHandle(taskHandleVersion)
 	handle.Config = cfg
 
@@ -359,6 +358,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	if err != nil {
 		return nil, nil, fmt.Errorf("Couldn't create image: %v", err)
 	}
+	d.logger.Debug("created/pulled image", "img_id", img.ID)
 
 	allArgs := []string{driverConfig.Image}
 	if driverConfig.Command != "" {
@@ -458,8 +458,8 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		User:              &cfg.User,
 		MemoryReservation: &driverConfig.MemoryReservation,
 		MemorySwap:        &swap,
-		Network:           &network,
 		MemorySwappiness:  swappiness,
+		Network:           &network,
 		Tmpfs:             &driverConfig.Tmpfs,
 	}
 

--- a/driver.go
+++ b/driver.go
@@ -444,15 +444,6 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		swap = driverConfig.MemorySwap
 	}
 
-	// Generate network string
-	var network string
-	if cfg.NetworkIsolation != nil &&
-		cfg.NetworkIsolation.Path != "" {
-		network = fmt.Sprintf("ns:%s", cfg.NetworkIsolation.Path)
-	} else {
-		network = driverConfig.NetworkMode
-	}
-
 	procFilesystems, err := getProcFilesystems()
 	swappiness := new(int64)
 	if err == nil {
@@ -463,6 +454,15 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		if cgroupv2 == false {
 			swappiness = &driverConfig.MemorySwappiness
 		}
+	}
+
+	// Generate network string
+	var network string
+	if cfg.NetworkIsolation != nil &&
+		cfg.NetworkIsolation.Path != "" {
+		network = fmt.Sprintf("ns:%s", cfg.NetworkIsolation.Path)
+	} else {
+		network = driverConfig.NetworkMode
 	}
 
 	createOpts := iopodman.Create{

--- a/driver.go
+++ b/driver.go
@@ -401,13 +401,13 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		if d.config.Volumes.Enabled {
 			v = volume
 		} else {
-			d.logger.Warn("Volumes", fmt.Sprintf("trying to mount %#v, which is outside the allocation directory, while volume mounting from host paths haven't been enabled", volume))
+			d.logger.Warn(fmt.Sprintf("volume: trying to mount %#v, which is outside the allocation directory, while volume mounting from host paths haven't been enabled", volume))
 		}
 
 		allVolumes = append(allVolumes, v)
 	}
 
-	d.logger.Debug("Volumes", fmt.Sprintf("%#v", allVolumes))
+	d.logger.Debug("volume info", "volumes", allVolumes)
 
 	// Apply SELinux Label to each volume
 	if selinuxLabel := d.config.Volumes.SelinuxLabel; selinuxLabel != "" {
@@ -784,8 +784,7 @@ func (d *Driver) createImage(cfg *drivers.TaskConfig, driverConfig *TaskConfig) 
 
 	}
 
-	d.logger.Debug("Image", fmt.Sprintf("%#v", img))
-	d.logger.Debug("Image config", fmt.Sprintf("%#v", img.Config))
+	d.logger.Debug("Image created", "img_id", img.ID, "config", img.Config)
 
 	return img, nil
 }

--- a/driver.go
+++ b/driver.go
@@ -355,23 +355,35 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("image name required")
 	}
 
+	img, err := d.podmanClient.InspectImage(driverConfig.Image)
+	if err != nil {
+		return nil, nil, fmt.Errorf("image %s couldn't be inspected", driverConfig.Image)
+	}
+	d.logger.Debug("Image", fmt.Sprintf("%#v", img))
+	d.logger.Debug("Image config", fmt.Sprintf("%#v", img.Config))
+
 	allArgs := []string{driverConfig.Image}
 	if driverConfig.Command != "" {
 		allArgs = append(allArgs, driverConfig.Command)
 	}
 	allArgs = append(allArgs, driverConfig.Args...)
+
+	var entryPoint *string // nil -> image default entryPoint
+	if driverConfig.Entrypoint != "" {
+		*entryPoint = driverConfig.Entrypoint
+	}
+
+	var workingDir *string // nil -> image default workingDir
+	if driverConfig.WorkingDir != "" {
+		*workingDir = driverConfig.WorkingDir
+	}
+
 	containerName := BuildContainerName(cfg)
 	memoryLimit := fmt.Sprintf("%dm", cfg.Resources.NomadResources.Memory.MemoryMB)
 	cpuShares := cfg.Resources.LinuxResources.CPUShares
 	logOpts := []string{
 		fmt.Sprintf("path=%s", cfg.StdoutPath),
 	}
-
-	// ensure to include port_map into tasks environment map
-	cfg.Env = taskenv.SetPortMapEnvs(cfg.Env, driverConfig.PortMap)
-
-	// convert environment map into a k=v list
-	allEnv := cfg.EnvList()
 
 	// ensure to mount nomad alloc dirs into the container
 	allVolumes := []string{
@@ -384,6 +396,17 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		// add task specific volumes, if enabled
 		allVolumes = append(allVolumes, driverConfig.Volumes...)
 	}
+	d.logger.Debug("Volumes", fmt.Sprintf("%#v", allVolumes))
+
+	// reset env so we don't inherit host env by default
+	cfg.Env = make(map[string]string)
+	// ensure to include port_map into tasks environment map
+	cfg.Env = taskenv.SetPortMapEnvs(cfg.Env, driverConfig.PortMap)
+	// Set the env to image defaults
+	allEnv := img.Config.Env
+	// convert environment map into a k=v list
+	allEnv = append(allEnv, cfg.EnvList()...)
+	d.logger.Debug("Env", fmt.Sprintf("%#v", allEnv))
 
 	// Apply SELinux Label to each volume
 	if selinuxLabel := d.config.Volumes.SelinuxLabel; selinuxLabel != "" {
@@ -408,6 +431,8 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 
 	createOpts := iopodman.Create{
 		Args:              allArgs,
+		Entrypoint:        entryPoint,
+		WorkDir:           workingDir,
 		Env:               &allEnv,
 		Name:              &containerName,
 		Volume:            &allVolumes,

--- a/driver.go
+++ b/driver.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"strings"
+	"os/user"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 
@@ -160,7 +162,24 @@ func (d *Driver) SetConfig(cfg *base.Config) error {
 		d.nomadConfig = cfg.AgentConfig.Driver
 	}
 
-	d.podmanClient.varlinkSocketPath = config.SocketPath
+	if config.SocketPath != "" {
+		d.podmanClient.varlinkSocketPath = config.SocketPath
+	} else {
+		user, _ := user.Current()
+		procFilesystems, err := getProcFilesystems()
+
+		if err != nil {
+			return err
+		}
+
+		socketPath := guessSocketPath(user, procFilesystems)
+
+		if err != nil {
+			return err
+		}
+
+		d.podmanClient.varlinkSocketPath = socketPath
+	}
 
 	return nil
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/client/taskenv"
 	dtestutil "github.com/hashicorp/nomad/plugins/drivers/testutils"
 	tu "github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
@@ -265,6 +266,7 @@ func TestPodmanDriver_Start_Wait_AllocDir(t *testing.T) {
 
 	exp := []byte{'w', 'i', 'n'}
 	file := "output.txt"
+	allocDir := "/mnt/alloc"
 
 	taskCfg := newTaskConfig("", []string{
 		"sh",
@@ -272,6 +274,7 @@ func TestPodmanDriver_Start_Wait_AllocDir(t *testing.T) {
 		fmt.Sprintf(`echo -n %s > $%s/%s; sleep 1`,
 			string(exp), taskenv.AllocDir, file),
 	})
+	taskCfg.Volumes = []string{fmt.Sprintf("alloc/:%s", allocDir)}
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "start_wait_allocDir",

--- a/driver_test.go
+++ b/driver_test.go
@@ -816,8 +816,14 @@ func TestPodmanDriver_Swap(t *testing.T) {
 	require.Equal(t, int64(52428800), inspectData.HostConfig.Memory)
 	require.Equal(t, int64(41943040), inspectData.HostConfig.MemoryReservation)
 	require.Equal(t, int64(104857600), inspectData.HostConfig.MemorySwap)
-	require.Equal(t, int64(60), inspectData.HostConfig.MemorySwappiness)
 
+	procFilesystems, err := getProcFilesystems()
+	if err == nil {
+		cgroupv2 := isCGroupV2(procFilesystems)
+		if cgroupv2 == false {
+			require.Equal(t, int64(60), inspectData.HostConfig.MemorySwappiness)
+		}
+	}
 }
 
 // check tmpfs mounts

--- a/driver_test.go
+++ b/driver_test.go
@@ -957,9 +957,7 @@ func readLogfile(t *testing.T, task *drivers.TaskConfig) string {
 }
 
 func newTaskConfig(variant string, command []string) TaskConfig {
-	// busyboxImageID is the ID stored in busybox.tar
-	busyboxImageID := "docker://busybox"
-	// busyboxImageID := "busybox:1.29.3"
+	busyboxImageID := "docker://docker.io/library/busybox:latest"
 
 	image := busyboxImageID
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -665,7 +665,7 @@ func TestPodmanDriver_OOM(t *testing.T) {
 		// Incrementally creates a bigger and bigger variable.
 		"sh",
 		"-c",
-		"x=a; while true; do eval x='$x$x'; done",
+		"tail /dev/zero",
 	})
 
 	// only enable init if catatonit is installed

--- a/driver_test.go
+++ b/driver_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
-	"github.com/hashicorp/nomad/client/taskenv"
 	dtestutil "github.com/hashicorp/nomad/plugins/drivers/testutils"
 	tu "github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"

--- a/driver_test.go
+++ b/driver_test.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"testing"
 	"time"
+	"flag"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-driver-podman/iopodman"
@@ -47,6 +48,7 @@ var (
 	// busyboxLongRunningCmd is a busybox command that runs indefinitely, and
 	// ideally responds to SIGINT/SIGTERM.  Sadly, busybox:1.29.3 /bin/sleep doesn't.
 	busyboxLongRunningCmd = []string{"nc", "-l", "-p", "3000", "127.0.0.1"}
+	varlinkSocketPath = ""
 )
 
 func createBasicResources() *drivers.Resources {
@@ -967,8 +969,7 @@ func getContainer(t *testing.T, containerName string) iopodman.Container {
 }
 
 func getPodmanConnection(ctx context.Context) (*varlink.Connection, error) {
-	// FIXME: a parameter for the socket would be nice
-	varlinkConnection, err := varlink.NewConnection(ctx, "unix://run/podman/io.podman")
+	varlinkConnection, err := varlink.NewConnection(ctx, *varlinkSocketPath)
 	return varlinkConnection, err
 }
 
@@ -980,6 +981,7 @@ func newPodmanClient() *PodmanClient {
 	client := &PodmanClient{
 		ctx:    context.Background(),
 		logger: testLogger,
+		varlinkSocketPath: *varlinkSocketPath,
 	}
 	return client
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/container-storage-interface/spec v1.2.0 // indirect
 	github.com/containernetworking/plugins v0.8.5 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/hashicorp/consul v1.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -795,6 +795,7 @@ github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKv
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=

--- a/handle.go
+++ b/handle.go
@@ -201,7 +201,6 @@ func (h *TaskHandle) runContainerMonitor() {
 						h.exitResult.Err = fmt.Errorf("Podman container killed by OOM killer")
 						h.logger.Error("Podman container killed by OOM killer", "container", h.containerID)
 					}
-					h.logger.Debug("Container inspect data", "container", h.containerID, "inspect_data", fmt.Sprintf("%#v", inspectData))
 				}
 
 				h.procState = drivers.TaskStateExited

--- a/handle.go
+++ b/handle.go
@@ -177,7 +177,7 @@ func (h *TaskHandle) runContainerMonitor() {
 		}
 
 		containerStats, err := h.driver.podmanClient.GetContainerStats(h.containerID)
-		h.logger.Debug("Container stats", "container", h.containerID, "stats", fmt.Sprintf("%#v", containerStats))
+		h.logger.Trace("Container stats", "container", h.containerID, "stats", containerStats)
 		if err != nil {
 			if _, ok := err.(*iopodman.NoContainerRunning); ok {
 				h.logger.Debug("Container is not running anymore", "container", h.containerID)

--- a/handle.go
+++ b/handle.go
@@ -177,6 +177,7 @@ func (h *TaskHandle) runContainerMonitor() {
 		}
 
 		containerStats, err := h.driver.podmanClient.GetContainerStats(h.containerID)
+		h.logger.Debug("Container stats", "container", h.containerID, "stats", fmt.Sprintf("%#v", containerStats))
 		if err != nil {
 			if _, ok := err.(*iopodman.NoContainerRunning); ok {
 				h.logger.Debug("Container is not running anymore", "container", h.containerID)
@@ -190,13 +191,19 @@ func (h *TaskHandle) runContainerMonitor() {
 					h.completedAt = time.Now()
 				} else {
 					h.exitResult.ExitCode = int(inspectData.State.ExitCode)
+					if len(inspectData.State.Error) > 0 {
+						h.exitResult.Err = fmt.Errorf(inspectData.State.Error)
+						h.logger.Error("Container error", "container", h.containerID, "err", fmt.Sprintf("%s", h.exitResult.Err.Error()))
+					}
 					h.completedAt = inspectData.State.FinishedAt
 					if inspectData.State.OOMKilled {
 						h.exitResult.OOMKilled = true
 						h.exitResult.Err = fmt.Errorf("Podman container killed by OOM killer")
 						h.logger.Error("Podman container killed by OOM killer", "container", h.containerID)
 					}
+					h.logger.Debug("Container inspect data", "container", h.containerID, "inspect_data", fmt.Sprintf("%#v", inspectData))
 				}
+
 				h.procState = drivers.TaskStateExited
 				h.stateLock.Unlock()
 				return

--- a/handle.go
+++ b/handle.go
@@ -193,7 +193,7 @@ func (h *TaskHandle) runContainerMonitor() {
 					h.exitResult.ExitCode = int(inspectData.State.ExitCode)
 					if len(inspectData.State.Error) > 0 {
 						h.exitResult.Err = fmt.Errorf(inspectData.State.Error)
-						h.logger.Error("Container error", "container", h.containerID, "err", fmt.Sprintf("%s", h.exitResult.Err.Error()))
+						h.logger.Error("Container error", "container", h.containerID, "err", h.exitResult.Err)
 					}
 					h.completedAt = inspectData.State.FinishedAt
 					if inspectData.State.OOMKilled {

--- a/iopodman/inspect.go
+++ b/iopodman/inspect.go
@@ -110,6 +110,19 @@ type InspectContainerConfig struct {
 	// Healthcheck *manifest.Schema2HealthConfig `json:"Healthcheck,omitempty"`
 }
 
+type InspectImageData struct {
+	ID              string                 `json:"Id"`
+	Created         time.Time              `json:"Created"`
+	Config          *InspectImageConfig    `json:"Config"`
+}
+
+type InspectImageConfig struct {
+	Env         []string              `json:"Env"`
+	Entrypoint  []string              `json:"Entrypoint"`
+	Cmd         []string              `json:"Cmd"`
+	WorkingDir  string                `json:"WorkingDir"`
+}
+
 // InspectMount provides a record of a single mount in a container. It contains
 // fields for both named and normal volumes. Only user-specified volumes will be
 // included, and tmpfs volumes are not included even if the user specified them.

--- a/iopodman/inspect.go
+++ b/iopodman/inspect.go
@@ -178,7 +178,7 @@ type InspectContainerState struct {
 	Dead       bool      `json:"Dead"`
 	Pid        int       `json:"Pid"`
 	ExitCode   int32     `json:"ExitCode"`
-	Error      string    `json:"Error"` // TODO
+	Error      string    `json:"Error"`
 	StartedAt  time.Time `json:"StartedAt"`
 	FinishedAt time.Time `json:"FinishedAt"`
 	// Healthcheck HealthCheckResults `json:"Healthcheck,omitempty"`

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,4 +4,5 @@ go 1.14
 
 require (
 	github.com/golangci/golangci-lint v1.24.0
+	github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20200601163814-4a9e55fb9e7d // indirect
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -117,6 +117,9 @@ github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.m
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQLReU=
+github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20200601163814-4a9e55fb9e7d h1:J1hlEYAGIhvgB4qRFtaK+GyyvA4sJ52Th+rrXYY8pZ4=
+github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20200601163814-4a9e55fb9e7d/go.mod h1:f0uAs1kAopX4JXFgR4kMixWftM8qLha6edaFVawdNtg=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -317,6 +320,8 @@ golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200102140908-9497f49d5709/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200204192400-7124308813f3 h1:Ms82wn6YK4ZycO6Bxyh0kxX3gFFVGo79CCuc52xgcys=
 golang.org/x/tools v0.0.0-20200204192400-7124308813f3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200211205636-11eff242d136 h1:yFWeDNMOyrJIQNtXrNR5smCrv+Y4IN6Ul42TzAXxd9k=
+golang.org/x/tools v0.0.0-20200211205636-11eff242d136/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -6,4 +6,5 @@ package tools
 
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/hashicorp/go-hclog/hclogvet"
 )


### PR DESCRIPTION
@weeezes I wanted to make a few changes to your PR to address the env and volumes  changes. Could you let me know if it works in your scenario?

For me the following works:

job file
```
job "example" {
  datacenters = ["dc1"]
  type        = "service"

  group "cache" {
    count = 1
    restart {
      attempts = 2
      interval = "30m"
      delay    = "15s"
      mode     = "fail"
    }
    task "redis" {
      driver = "podman"

      config {
        image = "redis"

        port_map {
          db = 6379
        }

        volumes = [
          "alloc/:/mnt/alloc",
          "local/:/mnt/local",
          "secrets/:/mnt/secrets",
        ]
      }

      resources {
        cpu    = 500 # 500 MHz
        memory = 256 # 256MB

        network {
          # mbits = 10
          port "db" {}
        }
      }
    }
  }
}
```

```
→ podman ps
CONTAINER ID  IMAGE                           COMMAND       CREATED        STATUS            PORTS                                                 NAMES
b3d720029540  docker.io/library/redis:latest  redis-server  3 seconds ago  Up 2 seconds ago  127.0.0.1:26175->6379/tcp, 127.0.0.1:26175->6379/udp  redis-5cde6463-0174-de04-eaa0-3778b9ad0675
```
```
→ crun list
NAME                                                             PID       STATUS   BUNDLE PATH
b3d720029540d6f0e0a0333d5944e789ab7ffcf4b0748dd4a32b869b4292729b 70330     running  /home/drew/.local/share/containers/storage/vfs-containers/b3d720029540d6f0e0a0333d5944e789ab7ffcf4b0748dd4a32b869b4292729b/userdata
```