### PR TITLE
config: Ability to configure dns server list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+FEATURES:
+
+* config: Ability to configure dns server list
+
 ## 0.1.0
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ config {
 }
 ```
 
+* **dns** - (Optional)  A list of dns servers. Replaces the default from podman binary and containers.conf.
+
+```
+config {
+  dns = [
+    "1.1.1.1"
+  ]
+}
+```
+
 ## Example job
 
 ```

--- a/config.go
+++ b/config.go
@@ -59,6 +59,7 @@ var (
 		"command":            hclspec.NewAttr("command", "string", false),
 		"cap_add":            hclspec.NewAttr("cap_add", "list(string)", false),
 		"cap_drop":           hclspec.NewAttr("cap_drop", "list(string)", false),
+		"dns":                hclspec.NewAttr("dns", "list(string)", false),
 		"entrypoint":         hclspec.NewAttr("entrypoint", "string", false),
 		"working_dir":        hclspec.NewAttr("working_dir", "string", false),
 		"hostname":           hclspec.NewAttr("hostname", "string", false),
@@ -113,4 +114,5 @@ type TaskConfig struct {
 	Volumes           []string           `codec:"volumes"`
 	CapAdd            []string           `codec:"cap_add"`
 	CapDrop           []string           `codec:"cap_drop"`
+	Dns               []string           `codec:"dns"`
 }

--- a/driver.go
+++ b/driver.go
@@ -433,6 +433,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		CpuShares:         &cpuShares,
 		CapAdd:            &driverConfig.CapAdd,
 		CapDrop:           &driverConfig.CapDrop,
+		Dns:               &driverConfig.Dns,
 		LogOpt:            &logOpts,
 		Hostname:          &driverConfig.Hostname,
 		Init:              &driverConfig.Init,


### PR DESCRIPTION
Driver config can now specify a list of dns servers:


* **dns** - (Optional)  A list of dns servers. Replaces the default from podman binary and containers.conf.

```
config {
  dns = [
    "1.1.1.1"
  ]
}
```
