### PR TITLE
add exec support

### DIFF
--- a/api/exec.go
+++ b/api/exec.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	docker "github.com/docker/docker/api/types"
+)
+
+type ExecCreateConfig struct {
+	docker.ExecConfig
+}
+
+type ExecCreateResponse struct {
+	docker.IDResponse
+}
+
+type ExecStartConfig struct {
+	Detach bool `json:"Detach"`
+	Tty    bool `json:"Tty"`
+}
+
+func (c *API) CreateExec(ctx context.Context, container string, opts ExecCreateConfig) (*ExecCreateResponse, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.Post(ctx, fmt.Sprintf("/v1.0.0/libpod/containers/%s/exec", container), bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ExecCreateResponse{}
+	if err = json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/driver.go
+++ b/driver.go
@@ -701,7 +701,19 @@ func (d *Driver) SignalTask(taskID string, signal string) error {
 
 // ExecTask function is used by the Nomad client to execute commands inside the task execution context.
 func (d *Driver) ExecTask(taskID string, cmd []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
-	return nil, fmt.Errorf("Podman driver does not support exec")
+	task, ok := d.tasks.Get(taskID)
+	if !ok {
+		return nil, drivers.ErrTaskNotFound
+	}
+
+	if len(cmd) == 0 {
+		return nil, fmt.Errorf("cmd is required, but was empty")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return task.Exec(ctx, cmd[0], cmd[1:])
 }
 
 func (d *Driver) containerMounts(task *drivers.TaskConfig, driverConfig *TaskConfig) ([]spec.Mount, error) {

--- a/examples/payload.json
+++ b/examples/payload.json
@@ -1,0 +1,8 @@
+{
+  "AttachStdin": false,
+  "AttachStdout": true,
+  "AttachStderr": true,
+  "Cmd": ["sh"],
+  "Privileged": true,
+  "Tty": true
+}

--- a/examples/payload2.json
+++ b/examples/payload2.json
@@ -1,0 +1,4 @@
+{
+  "Detach": false,
+  "Tty": true
+}

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,10 @@ replace (
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/container-storage-interface/spec v1.2.0 // indirect
 	github.com/containernetworking/plugins v0.8.5 // indirect
+	github.com/docker/docker v17.12.0-ce-rc1.0.20200330121334-7f8b4b621b5d+incompatible
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/google/go-cmp v0.5.0 // indirect


### PR DESCRIPTION
Creating a Draft PR containing WIP for basic exec support.

I don't think we'll easily be able to support TTY without significant work in handling / upgrading connections to websockets, we may be able to shim the docker go api package to use their exec command against a podman endpoint