### PR TITLE
Improve container_start to improve startup of short living containers

### DIFF
--- a/api/container_start.go
+++ b/api/container_start.go
@@ -28,6 +28,6 @@ func (c *API) ContainerStart(ctx context.Context, name string) error {
 	timeout, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
-	err = c.ContainerWait(timeout, name, "running")
+	err = c.ContainerWait(timeout, name, []string{"running","exited"})
 	return err
 }

--- a/api/container_start.go
+++ b/api/container_start.go
@@ -28,6 +28,6 @@ func (c *API) ContainerStart(ctx context.Context, name string) error {
 	timeout, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
-	err = c.ContainerWait(timeout, name, []string{"running","exited"})
+	err = c.ContainerWait(timeout, name, []string{"running", "exited"})
 	return err
 }

--- a/api/container_wait.go
+++ b/api/container_wait.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // ContainerWait waits on a container to met a given condition
-func (c *API) ContainerWait(ctx context.Context, name string, condition string) error {
+func (c *API) ContainerWait(ctx context.Context, name string, conditions []string) error {
 
-	res, err := c.Post(ctx, fmt.Sprintf("/v1.0.0/libpod/containers/%s/wait?condition=%s", name, condition), nil)
+	res, err := c.Post(ctx, fmt.Sprintf("/v1.0.0/libpod/containers/%s/wait?condition=%s", name, strings.Join(conditions, "&condition=")), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Improve container startup state tracking. Some details can be found in #89 
It helps to overcome a race condition when running very short living containers in e.g. unit tests.

A better solution would be to continue on #80 