### PR TITLE
Adopt some rootless code to podman 3.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 * config: Support for sysctl configuration [[GH-82](https://github.com/hashicorp/nomad-driver-podman/issues/82)]
 * config: Fixed a bug where we always pulled an image if image name has a transport prefix [[GH-88](https://github.com/hashicorp/nomad-driver-podman/pull/88)]
 
+BUG FIXES:
+* [[GH-93](https://github.com/hashicorp/nomad-driver-podman/issues/93)] use slirp4netns as default network mode if running rootless
+* [[GH-92](https://github.com/hashicorp/nomad-driver-podman/issues/92)] parse rootless info correctly from podman 3.0.x struct
+
 ## 0.2.0
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd nomad-driver-podman
 - Linux host with `podman` installed
 - For rootless containers you need a system supporting cgroup V2 and a few other things, follow [this tutorial](https://github.com/containers/libpod/blob/master/docs/tutorials/rootless_tutorial.md)
 
-You need a 2.x podman binary and a system socket activation unit,
+You need a 3.0.x podman binary and a system socket activation unit,
 see https://www.redhat.com/sysadmin/podmans-new-rest-api
 
 Nomad agent, nomad-driver-podman and podman will reside on the same host, so you

--- a/api/structs.go
+++ b/api/structs.go
@@ -1406,30 +1406,39 @@ type Info struct {
 }
 
 //HostInfo describes the libpod host
+type SecurityInfo struct {
+	DefaultCapabilities string `json:"capabilities"`
+	AppArmorEnabled     bool   `json:"apparmorEnabled"`
+	Rootless            bool   `json:"rootless"`
+	SECCOMPEnabled      bool   `json:"seccompEnabled"`
+	SELinuxEnabled      bool   `json:"selinuxEnabled"`
+}
+
+//HostInfo describes the libpod host
 type HostInfo struct {
-	Arch           string           `json:"arch"`
-	BuildahVersion string           `json:"buildahVersion"`
-	CgroupManager  string           `json:"cgroupManager"`
-	CGroupsVersion string           `json:"cgroupVersion"`
-	Conmon         *ConmonInfo      `json:"conmon"`
-	CPUs           int              `json:"cpus"`
-	Distribution   DistributionInfo `json:"distribution"`
-	EventLogger    string           `json:"eventLogger"`
-	Hostname       string           `json:"hostname"`
-	// IDMappings     IDMappings             `json:"idMappings,omitempty"`
-	Kernel       string                 `json:"kernel"`
-	MemFree      int64                  `json:"memFree"`
-	MemTotal     int64                  `json:"memTotal"`
-	OCIRuntime   *OCIRuntimeInfo        `json:"ociRuntime"`
-	OS           string                 `json:"os"`
-	RemoteSocket *RemoteSocket          `json:"remoteSocket,omitempty"`
-	Rootless     bool                   `json:"rootless"`
-	RuntimeInfo  map[string]interface{} `json:"runtimeInfo,omitempty"`
-	Slirp4NetNS  SlirpInfo              `json:"slirp4netns,omitempty"`
-	SwapFree     int64                  `json:"swapFree"`
-	SwapTotal    int64                  `json:"swapTotal"`
-	Uptime       string                 `json:"uptime"`
-	Linkmode     string                 `json:"linkmode"`
+	Conmon       *ConmonInfo      `json:"conmon"`
+	Distribution DistributionInfo `json:"distribution"`
+	//IDMappings     IDMappings             `json:"idMappings,omitempty"`
+	OCIRuntime     *OCIRuntimeInfo        `json:"ociRuntime"`
+	RemoteSocket   *RemoteSocket          `json:"remoteSocket,omitempty"`
+	Security       SecurityInfo           `json:"security"`
+	Slirp4NetNS    SlirpInfo              `json:"slirp4netns,omitempty"`
+	RuntimeInfo    map[string]interface{} `json:"runtimeInfo,omitempty"`
+	Arch           string                 `json:"arch"`
+	BuildahVersion string                 `json:"buildahVersion"`
+	CgroupManager  string                 `json:"cgroupManager"`
+	CGroupsVersion string                 `json:"cgroupVersion"`
+	EventLogger    string                 `json:"eventLogger"`
+	Hostname       string                 `json:"hostname"`
+	Kernel         string                 `json:"kernel"`
+	OS             string                 `json:"os"`
+	Uptime         string                 `json:"uptime"`
+	Linkmode       string                 `json:"linkmode"`
+	MemFree        int64                  `json:"memFree"`
+	MemTotal       int64                  `json:"memTotal"`
+	SwapFree       int64                  `json:"swapFree"`
+	SwapTotal      int64                  `json:"swapTotal"`
+	CPUs           int                    `json:"cpus"`
 }
 
 // RemoteSocket describes information about the API socket


### PR DESCRIPTION
fix #92 parse rootless info correctly from podman 3.0.x struct
fix #93 use slirp4netns as default network mode if running rootless
Bump supported podman version in README to 3.0.x