### PR TITLE
Set tag when pulling image missing in local storage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/driver.go
+++ b/driver.go
@@ -507,6 +507,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 				return nil, nil, fmt.Errorf("failed to start task, unable to pull image %s : %v", imageName, err)
 			}
 		}
+		createOpts.Image = imageName
 
 		createResponse, err := d.podman.ContainerCreate(d.ctx, createOpts)
 		for _, w := range createResponse.Warnings {

--- a/driver.go
+++ b/driver.go
@@ -488,23 +488,23 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		//        e.g. oci-archive:/... etc
 		//        see also https://github.com/hashicorp/nomad-driver-podman/issues/69
 
-		imageName, tag, err := parseImage(createOpts.Image)
+		imageName, err := parseImage(createOpts.Image)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to start task, unable to parse image reference %s: %v", createOpts.Image, err)
 		}
 
 		// do we already have this image in local storage?
-		haveImage, err := d.podman.ImageExists(d.ctx, fmt.Sprintf("%s:%s", imageName, tag))
+		haveImage, err := d.podman.ImageExists(d.ctx, imageName)
 		if err != nil {
 			d.logger.Warn("Unable to check for local image", "image", imageName, "err", err)
 			// do NOT fail this operation, instead try to pull the image
 			haveImage = false
 		}
 		if !haveImage {
-			d.logger.Debug("Pull image", "image", fmt.Sprintf("%s:%s", imageName, tag))
+			d.logger.Debug("Pull image", "image", imageName)
 			// image is not in local storage, so we need to pull it
-			if err = d.podman.ImagePull(d.ctx, fmt.Sprintf("%s:%s", imageName, tag)); err != nil {
-				return nil, nil, fmt.Errorf("failed to start task, unable to pull image %s:%s : %v", imageName, tag, err)
+			if err = d.podman.ImagePull(d.ctx, imageName); err != nil {
+				return nil, nil, fmt.Errorf("failed to start task, unable to pull image %s : %v", imageName, err)
 			}
 		}
 
@@ -607,7 +607,7 @@ func memoryInBytes(strmem string) (int64, error) {
 	}
 }
 
-func parseImage(image string) (string, string, error) {
+func parseImage(image string) (string, error) {
 	// strip http/https and docker transport prefix
 	for _, prefix := range []string{"http://", "https://", "docker://"} {
 		if strings.HasPrefix(image, prefix) {
@@ -617,7 +617,7 @@ func parseImage(image string) (string, string, error) {
 
 	named, err := dockerref.ParseNormalizedNamed(image)
 	if err != nil {
-		return "", "", nil
+		return "", err
 	}
 
 	var tag, digest string
@@ -625,16 +625,17 @@ func parseImage(image string) (string, string, error) {
 	tagged, ok := named.(dockerref.Tagged)
 	if ok {
 		tag = tagged.Tag()
+		return fmt.Sprintf("%s:%s", named.Name(), tag), nil
 	}
 
 	digested, ok := named.(dockerref.Digested)
 	if ok {
 		digest = digested.Digest().String()
+		return fmt.Sprintf("%s@%s", named.Name(), digest), nil
 	}
-	if len(tag) == 0 && len(digest) == 0 {
-		tag = "latest"
-	}
-	return named.Name(), tag, nil
+
+	// Image is neither diggested, nor tagged. Default to 'latest'
+	return fmt.Sprintf("%s:%s", named.Name(), "latest"), nil
 }
 
 // WaitTask function is expected to return a channel that will send an *ExitResult when the task

--- a/driver.go
+++ b/driver.go
@@ -501,10 +501,10 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			haveImage = false
 		}
 		if !haveImage {
-			d.logger.Debug("Pull image", "image", imageName)
+			d.logger.Debug("Pull image", "image", fmt.Sprintf("%s:%s", imageName, tag))
 			// image is not in local storage, so we need to pull it
-			if err = d.podman.ImagePull(d.ctx, imageName); err != nil {
-				return nil, nil, fmt.Errorf("failed to start task, unable to pull image %s: %v", imageName, err)
+			if err = d.podman.ImagePull(d.ctx, fmt.Sprintf("%s:%s", imageName, tag)); err != nil {
+				return nil, nil, fmt.Errorf("failed to start task, unable to pull image %s:%s : %v", imageName, tag, err)
 			}
 		}
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -1357,6 +1357,35 @@ func TestPodmanDriver_Sysctl(t *testing.T) {
 
 }
 
+// Make sure we can pull and start "non-latest" containers
+func TestPodmanDriver_Pull(t *testing.T) {
+	if !tu.IsCI() {
+		t.Parallel()
+	}
+
+	testCases := []struct {
+		Image    string
+		TaskName string
+	}{
+		{Image: "busybox:unstable", TaskName: "pull_tag"},
+		{Image: "busybox", TaskName: "pull_non_tag"},
+		{Image: "busybox@sha256:ce98b632acbcbdf8d6fdc50d5f91fea39c770cd5b3a2724f52551dde4d088e96", TaskName: "pull_digest"},
+	}
+
+	for _, testCase := range testCases {
+		startDestroyInspectImage(t, testCase.Image, testCase.TaskName)
+	}
+}
+
+func startDestroyInspectImage(t *testing.T, image string, taskName string) {
+	taskCfg := newTaskConfig(image, busyboxLongRunningCmd)
+	inspectData := startDestroyInspect(t, taskCfg, taskName)
+
+	imageName, tag, err := parseImage(image)
+	require.NoError(t, err)
+	require.Equal(t, imageName+":"+tag, inspectData.Config.Image)
+}
+
 func Test_parseImage(t *testing.T) {
 	if !tu.IsCI() {
 		t.Parallel()


### PR DESCRIPTION
First of all, thank you very much for this plugin!

I was testing some basic configuration with nomad and this plugin and bumped into the following issue: 

With a clean podman installation, I tried to run the following task, which failed with `task=apache error="rpc error: code = Unknown desc = failed to start task, could not create container: unknown error, status code: 500: {"cause":"no such image","message":"unable to find 'docker.io/httpd:2' in local storage: no such image","response":500}"`
```
task "apache" {
  driver = "podman"

  config {
    image = "docker.io/httpd:2"
    ports = ["http"]
  }
}
```

To my surprise, the image saved to storage was `httpd:latest` instead of `httpd:2`. I understand the reason is that podman interprets the missing tag as `latest` when asking `ImagePull` just for the `imageName`

This PR fixes this issue and adds tag information to the logging and error in case the image is not present in local storage. I also understand that this should be the expected behavior according to the docker driver documentation.
