### PR TITLE
Fix errors missed while pulling images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         path: nomad-driver-podman
 
     - name: Test
-      run: sudo -E GOPATH=$PWD/build CI=1 build/bin/gotestsum --junitfile build/test/result.xml -- -timeout=15m .
+      run: sudo -E GOPATH=$PWD/build CI=1 build/bin/gotestsum --junitfile build/test/result.xml -- -timeout=15m . ./api
     - name: Archive test result
       uses: actions/upload-artifact@v1
       with:

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,9 @@
+package api
+
+import (
+	"github.com/hashicorp/go-hclog"
+)
+
+func newApi() *API {
+	return NewClient(hclog.Default(), DefaultClientConfig())
+}

--- a/api/image_pull.go
+++ b/api/image_pull.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
@@ -16,10 +19,23 @@ func (c *API) ImagePull(ctx context.Context, nameWithTag string) error {
 	}
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
-
 	if res.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(res.Body)
 		return fmt.Errorf("unknown error, status code: %d: %s", res.StatusCode, body)
+	}
+
+	dec := json.NewDecoder(res.Body)
+	var report ImagePullReport
+	for {
+		if err = dec.Decode(&report); err == io.EOF {
+			break
+		} else if err != nil {
+			return fmt.Errorf("Error reading response: %w", err)
+		}
+
+		if report.Error != "" {
+			return errors.New(report.Error)
+		}
 	}
 
 	return nil

--- a/api/image_pull_test.go
+++ b/api/image_pull_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApi_Image_Pull(t *testing.T) {
+	api := newApi()
+	ctx := context.Background()
+
+	testCases := []struct {
+		Image  string
+		Exists bool
+	}{
+		{Image: "docker.io/library/busybox", Exists: true},
+		{Image: "docker.io/library/busybox:unstable", Exists: true},
+		{Image: "docker.io/library/busybox:notag", Exists: false},
+		{Image: "docker.io/non-existent/image:tag", Exists: false},
+	}
+
+	for _, testCase := range testCases {
+		err := api.ImagePull(ctx, testCase.Image)
+		if testCase.Exists {
+			assert.NoError(t, err)
+		} else {
+			assert.Error(t, err)
+		}
+	}
+}

--- a/api/structs.go
+++ b/api/structs.go
@@ -1244,6 +1244,18 @@ type InspectExecProcess struct {
 	User string `json:"user"`
 }
 
+// ImagePullReport is the response from pulling one or more images.
+type ImagePullReport struct {
+	// Stream used to provide output from c/image
+	Stream string `json:"stream,omitempty"`
+	// Error contains text of errors from c/image
+	Error string `json:"error,omitempty"`
+	// Images contains the ID's of the images pulled
+	Images []string `json:"images,omitempty"`
+	// ID contains image id (retained for backwards compatibility)
+	ID string `json:"id,omitempty"`
+}
+
 // -------------------------------------------------------------------------------------------------------
 // structs loosly copied from https://github.com/containers/podman/blob/master/pkg/api/handlers/compat/types.go
 //         and https://github.com/moby/moby/blob/master/api/types/stats.go


### PR DESCRIPTION
On the /images/pull endpoint, podman's StatusOK response does
not warranty that the image was actually pulled, just that
the request was well formatted and no InteralServerError happened.
If any error happens during the download, the error is written to
the output stream in the error field.

I bumped into this by doing a typo in an image name. The driver failed creating the container complaining about a missing image, which in theory had been pulled but was not in the container store. Manually requesting the API for the image yielded this result:
```
{"stream":"Trying to pull docker.io/library/nextcloud:alpine...\n"}
{"stream":"  manifest unknown: manifest unknown\n"}
{"error":"Error initializing source docker://nextcloud:alpine: Error reading manifest alpine in docker.io/library/nextcloud: manifest unknown: manifest unknown\n"}
```
This PR should fix that problem.

I think ideally a test should be added to check this behavior at the API level. However, as no API method has a test, I wondered whethere there is a specific reason for that.