### PR TITLE
Update github action runner to ubuntu 20.04 and Podman 3.1.x

### DIFF
--- a/.github/machinesetup.sh
+++ b/.github/machinesetup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-# add podman 2.x repository
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key | apt-key add -
+# add podman repository
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/Release.key | apt-key add -
 
 # Ignore apt-get update errors to avoid failing due to misbehaving repo;
 # true errors would fail in the apt-get install phase
@@ -25,7 +25,7 @@ podman info
 echo "====== Podman version:"
 podman version
 
-# enable http socket (not included in ubuntu package)
+# enable http socket 
 cat > /etc/systemd/system/podman.service << EOF
 [Unit]
 Description=Podman API Service

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,15 @@
 name: build
 
-on: [push, pull_request]
+on: 
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
[Podman team announced ](https://podman.io/blogs/2021/03/02/podman-support-for-older-distros.html) that they will no longer build packages for Ubuntu 18.04. 

This PR upgrades our github action runner to Ubuntu 20.04 and this brings us also from podman 3.0.1 to podman 3.1.x.