### PR TITLE
Fix network_mode=container:$id network option

### DIFF
--- a/api/structs.go
+++ b/api/structs.go
@@ -546,7 +546,7 @@ const (
 // Namespace describes the namespace
 type Namespace struct {
 	NSMode NamespaceMode `json:"nsmode,omitempty"`
-	Value  string        `json:"string,omitempty"`
+	Value  string        `json:"value,omitempty"`
 }
 
 // -------------------------------------------------------------------------------------------------------

--- a/driver.go
+++ b/driver.go
@@ -453,6 +453,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			createOpts.ContainerNetworkConfig.NetNS.NSMode = api.NoNetwork
 		} else if driverConfig.NetworkMode == "slirp4netns" {
 			createOpts.ContainerNetworkConfig.NetNS.NSMode = api.Slirp
+		} else if strings.HasPrefix(driverConfig.NetworkMode, "container:") {
+			createOpts.ContainerNetworkConfig.NetNS.NSMode = api.FromContainer
+			createOpts.ContainerNetworkConfig.NetNS.Value = strings.TrimPrefix(driverConfig.NetworkMode, "container:")
 		} else {
 			return nil, nil, fmt.Errorf("Unknown/Unsupported network mode: %s", driverConfig.NetworkMode)
 		}


### PR DESCRIPTION
README explains that we can use network_mode = container:$othercontainer to let one container joint the network of another, already running, container. This feature was not really implemented.

This PR adds now the missing implementation, fixes a podman json structure and includes a unit test. 