### PR TITLE
Improved StopTask in case that container was lost outside nomad

### DIFF
--- a/api/container_inspect.go
+++ b/api/container_inspect.go
@@ -20,6 +20,10 @@ func (c *API) ContainerInspect(ctx context.Context, name string) (InspectContain
 
 	defer res.Body.Close()
 
+	if res.StatusCode == http.StatusNotFound {
+		return inspectData, ContainerNotFound
+	}
+
 	if res.StatusCode != http.StatusOK {
 		return inspectData, fmt.Errorf("unknown error, status code: %d", res.StatusCode)
 	}

--- a/api/container_stop.go
+++ b/api/container_stop.go
@@ -10,14 +10,18 @@ import (
 // timeout value.  The timeout value the time before a forcible stop to the container is applied.
 // If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
 // error will be returned instead.
-func (c *API) ContainerStop(ctx context.Context, name string, timeout int) error {
+func (c *API) ContainerStop(ctx context.Context, name string, timeout int, ignoreStopped bool) error {
 
-	res, err := c.Post(ctx, fmt.Sprintf("/v1.0.0/libpod/containers/%s/stop?timeout=%d", name, timeout), nil)
+	res, err := c.Post(ctx, fmt.Sprintf("/v1.0.0/libpod/containers/%s/stop?timeout=%d&ignore=%t", name, timeout, ignoreStopped), nil)
 	if err != nil {
 		return err
 	}
 
 	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		return ContainerNotFound
+	}
 
 	if res.StatusCode == http.StatusNoContent {
 		return nil

--- a/driver.go
+++ b/driver.go
@@ -730,13 +730,13 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	}
 
 	// fixme send proper signal to container
-    err := d.podman.ContainerStop(d.ctx, handle.containerID, int(timeout.Seconds()), true)
-    if err == nil {
-        return nil
-    } else if err == api.ContainerNotFound {
+	err := d.podman.ContainerStop(d.ctx, handle.containerID, int(timeout.Seconds()), true)
+	if err == nil {
+		return nil
+	} else if err == api.ContainerNotFound {
 		d.logger.Debug("Container not found while we wanted to stop it", "task", taskID, "container", handle.containerID, "err", err)
-        return nil
-    } else {
+		return nil
+	} else {
 		d.logger.Error("Could not stop/kill container", "containerID", handle.containerID, "err", err)
 		return err
 	}

--- a/driver.go
+++ b/driver.go
@@ -657,7 +657,7 @@ func (d *Driver) createImage(image string, auth *AuthConfig) (string, error) {
 		d.logger.Warn("Unable to check for local image", "image", imageName, "err", err)
 	}
 	if imageID != "" {
-		d.logger.Info("Found imageID", imageID, "for image", imageName, "in local storage")
+		d.logger.Debug("Found imageID", imageID, "for image", imageName, "in local storage")
 		return imageID, nil
 	}
 
@@ -728,29 +728,18 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	if !ok {
 		return drivers.ErrTaskNotFound
 	}
-	_, err := d.podman.ContainerStats(d.ctx, handle.containerID)
-	if err == api.ContainerNotFound {
-		// container is gone, we do not need to stop it
-		d.logger.Warn("Container is gone, no need to stop it", "task", taskID, "container", handle.containerID, "err", err)
-		return nil
-	} else if err == api.ContainerWrongState {
-		// container is not running, no need to stop it
-		d.logger.Warn("Found stopped container while stopping a task", "task", taskID, "container", handle.containerID, "err", err)
-		return nil
-	} else if err != nil {
-		d.logger.Warn("Unable to get container state while stopping a task, assuming it is dead", "task", taskID, "container", handle.containerID, "err", err)
-		// we assume that the container does not exist anymore
-		// returning nil pretends that the task was stopped
-		// returning err will retry later, but a lost/broken container would still end up here.
-		return nil
-	}
+
 	// fixme send proper signal to container
-	err = d.podman.ContainerStop(d.ctx, handle.containerID, int(timeout.Seconds()))
-	if err != nil {
+    err := d.podman.ContainerStop(d.ctx, handle.containerID, int(timeout.Seconds()), true)
+    if err == nil {
+        return nil
+    } else if err == api.ContainerNotFound {
+		d.logger.Debug("Container not found while we wanted to stop it", "task", taskID, "container", handle.containerID, "err", err)
+        return nil
+    } else {
 		d.logger.Error("Could not stop/kill container", "containerID", handle.containerID, "err", err)
 		return err
 	}
-	return nil
 }
 
 // DestroyTask function cleans up and removes a task that has terminated.
@@ -768,7 +757,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 	if handle.isRunning() {
 		d.logger.Debug("Have to destroyTask but container is still running", "containerID", handle.containerID)
 		// we can not do anything, so catching the error is useless
-		err := d.podman.ContainerStop(d.ctx, handle.containerID, 60)
+		err := d.podman.ContainerStop(d.ctx, handle.containerID, 60, true)
 		if err != nil {
 			d.logger.Warn("failed to stop/kill container during destroy", "error", err)
 		}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1642,7 +1642,7 @@ func readLogfile(t *testing.T, task *drivers.TaskConfig) string {
 
 func newTaskConfig(image string, command []string) TaskConfig {
 	if len(image) == 0 {
-		image = "docker://docker.io/library/busybox:latest"
+		image = "docker.io/library/busybox:latest"
 	}
 
 	return TaskConfig{


### PR DESCRIPTION
Handle stopped and unknown/lost containers correctly while stopping a task.
The previous version let nomad run circles around lost containers. This happend when a group was reallocated to another node when a host was rebooted. After rebook, nomad tried to stop the already stopped container etc.  
I found that the docker driver has a similar if/else chain in StopTask, so i reassembled it here.