### PR TITLE
Add flexible network namespaces and shared group network namespace support for consul connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,54 @@ this plugin to Nomad!
 * Fine tune memory usage: standard [Nomad memory resource](https://www.nomadproject.io/docs/job-specification/resources.html#memory) plus additional driver specific swap, swappiness and reservation parameters, OOM handling
 * Supports rootless containers with cgroup V2
 * Set DNS servers, searchlist and options via [Nomad dns parameters](https://www.nomadproject.io/docs/job-specification/network#dns-parameters)
+* Support for nomad shared network namespaces and consul connect
+* Quite flexible [network configuration](network-configuration), allows to simply build pod-like structures within a nomad group
 
+## Redis Example job
+
+Here is a simple redis "hello world" Example:
+
+```
+job "redis" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "redis" {
+    network {
+      port "redis" { to = 6379 }
+    }
+
+    task "redis" {
+      driver = "podman"
+
+        config {
+          image = "docker://redis"
+          ports = ["redis"]
+        }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+    }
+  }
+}
+```
+
+```sh
+nomad run redis.nomad
+
+==> Monitoring evaluation "9fc25b88"
+    Evaluation triggered by job "redis"
+    Allocation "60fdc69b" created: node "f6bccd6d", group "redis"
+    Evaluation status changed: "pending" -> "complete"
+==> Evaluation "9fc25b88" finished with status "complete"
+
+podman ps
+
+CONTAINER ID  IMAGE                           COMMAND               CREATED         STATUS             PORTS  NAMES
+6d2d700cbce6  docker.io/library/redis:latest  docker-entrypoint...  16 seconds ago  Up 16 seconds ago         redis-60fdc69b-65cb-8ece-8554-df49321b3462
+```
 
 ## Building The Driver from source
 
@@ -249,13 +296,13 @@ By default the task uses the network stack defined in the task group, see [netwo
 
 - `bridge`: create a network stack on the default podman bridge.
 - `none`: no networking
-- `container:id`: reuse another container's network stack
 - `host`: use the Podman host network stack. Note: the host mode gives the
   container full access to local system services such as D-bus and is therefore
   considered insecure
 - `slirp4netns`: use `slirp4netns` to create a user network stack. This is the
   default for rootless containers. Podman currently does not support it for root
   containers [issue](https://github.com/containers/libpod/issues/6097).
+- `container:id`: reuse another podman containers network stack
 - `task:name-of-other-task`: join the network of another task in the same allocation.
 
 ```
@@ -296,52 +343,51 @@ config {
 
 * **tty** - (Optional)  true or false (default). Allocate a pseudo-TTY for the container.
 
+## Network Configuration
 
-## Example job
+[nomad lifecycle hooks](https://www.nomadproject.io/docs/job-specification/lifecycle) combined with the drivers `network_mode` allows very flexible network namespace definitions. This feature does not build upon the native podman pod structure but simply reuses the networking namespace of one container for other tasks in the same group.
 
-```
-job "redis" {
-  datacenters = ["dc1"]
-  type        = "service"
+A typical example is a network server and a metric exporter or log shipping sidecar. The metric exporter needs access to i.E. a private monitoring Port which should not be exposed the the network and thus is usually bound to localhost.
 
-  group "redis" {
-    network {
-      port "redis" { to = 6379 }
-    }
+The repository includes three different examples jobs for such a setup. All of them will start a [nats](https://nats.io/) server and a [prometheus-nats-exporter](https://github.com/nats-io/prometheus-nats-exporter) using different approaches.
 
-    task "redis" {
-      driver = "podman"
+You can use `curl` to proof that the job is working correctly and that you can get prometheus metrics:
 
-        config {
-          image = "docker://redis"
-          ports = ["redis"]
-        }
+`curl http://your-machine:7777/metrics`
 
-      resources {
-        cpu    = 500
-        memory = 256
-      }
-    }
-  }
-}
-```
+### 2 Task setup, server defines the network
 
-```sh
-nomad run redis.nomad
+See `examples/jobs/nats_simple_pod.nomad`
 
-==> Monitoring evaluation "9fc25b88"
-    Evaluation triggered by job "redis"
-    Allocation "60fdc69b" created: node "f6bccd6d", group "redis"
-    Evaluation status changed: "pending" -> "complete"
-==> Evaluation "9fc25b88" finished with status "complete"
+Here, the *server* task is started as main workload and the *exporter* runs as a poststart sidecar. 
+Because of that, nomad guarantees that the server is started first and thus the exporter can
+easily join the servers network namespace via `network_mode = "task:server"`.
 
-podman ps
+Note, that the *server* configuration file binds the *http_port* to localhost. 
 
-CONTAINER ID  IMAGE                           COMMAND               CREATED         STATUS             PORTS  NAMES
-6d2d700cbce6  docker.io/library/redis:latest  docker-entrypoint...  16 seconds ago  Up 16 seconds ago         redis-60fdc69b-65cb-8ece-8554-df49321b3462
-```
+Be aware that ports must be defined in the parent network namespace, here *server*.
 
-### Rootless on ubuntu
+### 3 Task setup, a pause container defines the network
+
+See `examples/jobs/nats_pod.nomad`
+
+A slightly different setup is demonstrated in this job. It reassembles more closesly the idea of a *pod* by starting a
+pause task, named *pod* via a prestart/sidecar [hook](https://www.nomadproject.io/docs/job-specification/lifecycle).
+
+Next, the main workload, *server* is started and joins the network namespace by using the `network_mode = "task:pod"` stanza.
+Finally, nomad starts the poststart/sidecar *exporter* which also joins the network.
+
+Note that all ports must be defined on the *pod* level.
+
+### 2 Task setup, shared nomad network namespace
+
+See `examples/jobs/nats_group.nomad`
+
+This example is very different. Both *server* and *exporter* join a network namespace which is created and managed
+by nomad itself. See [nomad network stanza](https://www.nomadproject.io/docs/job-specification/network) to get started with this generic approach.
+
+
+## Rootless on ubuntu
 
 edit `/etc/default/grub` to enable cgroups v2
 ```
@@ -414,14 +460,14 @@ CONTAINER ID  IMAGE                           COMMAND       CREATED        STATU
 2423ae3efa21  docker.io/library/redis:latest  redis-server  7 seconds ago  Up 6 seconds ago  127.0.0.1:21510->6379/tcp, 127.0.0.1:21510->6379/udp  redis-b640480f-4b93-65fd-7bba-c15722886395
 ```
 
-### Local Development
+## Local Development
 
-#### Requirements
+### Requirements
 
   - Vagrant >= 2.2
   - VirtualBox >= v6.0
 
-#### Vagrant Environment Setup
+### Vagrant Environment Setup
 
 ```
 # create the vm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-iomad podman Driver
+Nomad podman Driver
 ==================
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Nomad podman Driver
+iomad podman Driver
 ==================
 
 
@@ -245,7 +245,9 @@ config {
 
 * **network_mode** - Set the [network mode](http://docs.podman.io/en/latest/markdown/podman-run.1.html#options) for the container.
 
-- `bridge`: (default for rootful) create a network stack on the default bridge
+By default the task uses the network stack defined in the task group, see [network Stanza](https://www.nomadproject.io/docs/job-specification/network). If the groups network behavior is also undefined, it will fallback to `bridge` in rootful mode or `slirp4netns` for rootless containers.
+
+- `bridge`: create a network stack on the default podman bridge.
 - `none`: no networking
 - `container:id`: reuse another container's network stack
 - `host`: use the Podman host network stack. Note: the host mode gives the
@@ -254,6 +256,7 @@ config {
 - `slirp4netns`: use `slirp4netns` to create a user network stack. This is the
   default for rootless containers. Podman currently does not support it for root
   containers [issue](https://github.com/containers/libpod/issues/6097).
+- `task:name-of-other-task`: join the network of another task in the same allocation.
 
 ```
 config {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ this plugin to Nomad!
 * Supports rootless containers with cgroup V2
 * Set DNS servers, searchlist and options via [Nomad dns parameters](https://www.nomadproject.io/docs/job-specification/network#dns-parameters)
 * Support for nomad shared network namespaces and consul connect
-* Quite flexible [network configuration](network-configuration), allows to simply build pod-like structures within a nomad group
+* Quite flexible [network configuration](#network-configuration), allows to simply build pod-like structures within a nomad group
 
 ## Redis Example job
 

--- a/driver.go
+++ b/driver.go
@@ -323,7 +323,12 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 
 // BuildContainerName returns the podman container name for a given TaskConfig
 func BuildContainerName(cfg *drivers.TaskConfig) string {
-	return fmt.Sprintf("%s-%s", cfg.Name, cfg.AllocID)
+	return BuildContainerNameForTask(cfg.Name, cfg)
+}
+
+// BuildContainerName returns the podman container name for a specific Task in our group
+func BuildContainerNameForTask(taskName string, cfg *drivers.TaskConfig) string {
+	return fmt.Sprintf("%s-%s", taskName, cfg.AllocID)
 }
 
 // StartTask creates and starts a new Container based on the given TaskConfig.
@@ -467,9 +472,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			createOpts.ContainerNetworkConfig.NetNS.NSMode = api.Path
 			createOpts.ContainerNetworkConfig.NetNS.Value = strings.TrimPrefix(driverConfig.NetworkMode, "ns:")
 		} else if strings.HasPrefix(driverConfig.NetworkMode, "task:") {
+			otherTaskName := strings.TrimPrefix(driverConfig.NetworkMode, "task:")
 			createOpts.ContainerNetworkConfig.NetNS.NSMode = api.FromContainer
-			otherContainerName := fmt.Sprintf("%s-%s", strings.TrimPrefix(driverConfig.NetworkMode, "task:"), cfg.AllocID)
-			createOpts.ContainerNetworkConfig.NetNS.Value = otherContainerName
+			createOpts.ContainerNetworkConfig.NetNS.Value = BuildContainerNameForTask(otherTaskName, cfg)
 		} else {
 			return nil, nil, fmt.Errorf("Unknown/Unsupported network mode: %s", driverConfig.NetworkMode)
 		}

--- a/driver.go
+++ b/driver.go
@@ -747,24 +747,8 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	if !ok {
 		return drivers.ErrTaskNotFound
 	}
-	_, err := d.podman.ContainerStats(d.ctx, handle.containerID)
-	if err == api.ContainerNotFound {
-		// container is gone, we do not need to stop it
-		d.logger.Warn("Container is gone, no need to stop it", "task", taskID, "container", handle.containerID, "err", err)
-		return nil
-	} else if err == api.ContainerWrongState {
-		// container is not running, no need to stop it
-		d.logger.Warn("Found stopped container while stopping a task", "task", taskID, "container", handle.containerID, "err", err)
-		return nil
-	} else if err != nil {
-		d.logger.Warn("Unable to get container state while stopping a task, assuming it is dead", "task", taskID, "container", handle.containerID, "err", err)
-		// we assume that the container does not exist anymore
-		// returning nil pretends that the task was stopped
-		// returning err will retry later, but a lost/broken container would still end up here.
-		return nil
-	}
 	// fixme send proper signal to container
-	err = d.podman.ContainerStop(d.ctx, handle.containerID, int(timeout.Seconds()))
+	err := d.podman.ContainerStop(d.ctx, handle.containerID, int(timeout.Seconds()))
 	if err != nil {
 		d.logger.Error("Could not stop/kill container", "containerID", handle.containerID, "err", err)
 		return err

--- a/driver_test.go
+++ b/driver_test.go
@@ -1270,7 +1270,7 @@ func TestPodmanDriver_NetworkModes(t *testing.T) {
 	}
 }
 
-// let a task joint NetorkNS of another container via network_mode=container:
+// let a task join NetworkNS of another container via network_mode=container:
 func TestPodmanDriver_NetworkMode_Container(t *testing.T) {
 	if !tu.IsCI() {
 		t.Parallel()

--- a/examples/jobs/nats_pod.nomad
+++ b/examples/jobs/nats_pod.nomad
@@ -32,20 +32,8 @@ job "nats" {
         sidecar = "true"
       }
 
-      // server configuration file
-      template {
-        change_mode = "noop"
-        destination = "local/nats-server.conf"
-        data = file("./templates/nats-server.conf.tpl")
-      }
-
       config {
         image = "docker://k8s.gcr.io/pause:3.1"
-
-        args = [
-          "--config",
-          "/local/nats-server.conf"
-        ]
 
         // the "pod" task must define the complete network
         // port mapping here
@@ -61,11 +49,24 @@ job "nats" {
 
       // no "lifecycle" task: this is the main workload
 
+      // server configuration file
+      template {
+        change_mode = "noop"
+        destination = "local/nats-server.conf"
+        data = file("./templates/nats-server.conf.tpl")
+      }
+
       config {
         image = "docker://nats:2.2.6"
 
         // here we join the pods network namespace
         network_mode = "task:pod"
+
+        args = [
+          "--config",
+          "/local/nats-server.conf"
+        ]
+
       }
     }
 

--- a/examples/jobs/nats_pod.nomad
+++ b/examples/jobs/nats_pod.nomad
@@ -1,0 +1,71 @@
+//
+// This job runs a pair of nats-server and prometheus-nats-exporter tasks
+//
+// The exporter tasks runs in the network namespace of the server task
+// and can thus access the localhost http monitoring port without exposing it
+//
+// A curl http://<your-ip>:7777/metrics hits the exporter which in turn grabs
+// values from the nats-server
+//
+job "nats" {
+
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "nats" {
+
+    // Expose the default port for nats clients and 
+    // also the exporters http endpoint
+    network {
+      port "server" { static = 4222 }
+      port "exporter" { static = 7777 }
+    }
+
+    task "server" {
+      driver = "podman"
+
+      // no "lifecycle" task: this is the main workload
+
+      config {
+        image = "docker://nats:2.2.6"
+
+        // the "server" task must define the complete network
+        // environment, so we will also pre-define the exporter
+        // port mapping here
+        ports = [
+            "server",
+            "exporter"
+        ]
+      }
+    }
+
+    task "exporter" {
+
+      driver = "podman"
+
+      // ensure to run the exporter _after_ the server
+      // so that we can join the network namespace
+      lifecycle {
+        hook = "poststart"
+        sidecar = "true"
+      }
+
+      config {
+        image = "docker://natsio/prometheus-nats-exporter:0.7.0"
+
+        // here we join the servers network namespace
+        network_mode = "task:server"
+
+        // ... in order to access the private monitoring port
+        args = [
+          "-varz",
+          "http://localhost:8222"
+        ]
+      }
+    }
+
+  }
+}
+
+
+

--- a/examples/jobs/nats_pod.nomad
+++ b/examples/jobs/nats_pod.nomad
@@ -32,8 +32,20 @@ job "nats" {
         sidecar = "true"
       }
 
+      // server configuration file
+      template {
+        change_mode = "noop"
+        destination = "local/nats-server.conf"
+        data = file("./templates/nats-server.conf.tpl")
+      }
+
       config {
         image = "docker://k8s.gcr.io/pause:3.1"
+
+        args = [
+          "--config",
+          "/local/nats-server.conf"
+        ]
 
         // the "pod" task must define the complete network
         // port mapping here

--- a/examples/jobs/templates/nats-server.conf.tpl
+++ b/examples/jobs/templates/nats-server.conf.tpl
@@ -1,0 +1,15 @@
+# Client port of 4222 on all interfaces
+port: 4222
+
+# Allow ownly localhost access to the monitoring pot
+http: localhost:8222
+
+# This is for clustering multiple servers together.
+cluster {
+  # It is recommended to set a cluster name
+  name: "my_cluster"
+
+  # Route connections to be received on any interface on port 6222
+  port: 6222
+
+}


### PR DESCRIPTION
This PR add several new network related features.

First of all we can have now shared group network namespaces for e.g. consul connect. I aimed for rootful support and i am not sure if a rootless container can be joined to an existing network namespace somehow. 
A rootful container can, without any problems, join the nomad controlled network ns. We do not need a separate "pause" container like the docker driver implements it. This also means that this driver does not have to implement the CreateNetwork/DestroyNetwork hooks, so i it is more lightweight compared to the docker driver.

Additionally we have now two new network_mode values:

* network_mode = ns:/some/network/namespace  
* network_mode = task:name-of-other-task-in-same-group

The "task:" variant is very useful because a user can build arbitrary pod-like structures with it. The key is to combine lifecycle stanzas and the new mode. A prestart/sidecar task becomes the network namespace (e.g. pause container) and the main workload can reference it easily. Nice is that other tasks in the same group are not forced to join the namespace, they can still have their own mode.

- [ ] write more tests
- [x] write more documentation
- [x] add a pod example 

## Examples

examples/jobs/nats_pod.nomad shows how to run a pod with a pause, main-workload and exporter sidecar, all in a common network namespace:

![image](https://user-images.githubusercontent.com/8221469/120625608-2c0fbc80-c462-11eb-852f-c8641516ed73.png)

