### PR TITLE
config: correctly handle multiple mount options per bind mount

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -967,7 +967,7 @@ func (d *Driver) containerMounts(task *drivers.TaskConfig, driverConfig *TaskCon
 		}
 
 		if mode != "" {
-			bind.Options = append(bind.Options, mode)
+			bind.Options = append(bind.Options, strings.Split(mode, ",")...)
 		}
 		binds = append(binds, bind)
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1186,9 +1186,9 @@ func TestPodmanDriver_Mount(t *testing.T) {
 
 	// see if stdout was populated with expected "mount" output
 	tasklog := readLogfile(t, task)
-	require.Contains(t, tasklog, " on /checka type tmpfs ")
-	require.Contains(t, tasklog, " on /checkb type tmpfs ")
-	require.Contains(t, tasklog, " on /checkc type tmpfs ")
+	require.Contains(t, tasklog, " on /checka type ")
+	require.Contains(t, tasklog, " on /checkb type ")
+	require.Contains(t, tasklog, " on /checkc type ")
 }
 
 // check default capabilities


### PR DESCRIPTION
We did not handle multiple mount options correctly. A comma separated string was not split up but instead handed over as a single option, thus configuring the container failed. 

A test is added to proof that it is working correctly now.