### PR TITLE
Correctly recover containers after nomad restart when recover_stopped=false is configured.

### DIFF
--- a/api/container_inspect.go
+++ b/api/container_inspect.go
@@ -20,6 +20,10 @@ func (c *API) ContainerInspect(ctx context.Context, name string) (InspectContain
 
 	defer res.Body.Close()
 
+	if res.StatusCode == http.StatusNotFound {
+		return inspectData, ContainerNotFound
+	}
+
 	if res.StatusCode != http.StatusOK {
 		return inspectData, fmt.Errorf("unknown error, status code: %d", res.StatusCode)
 	}


### PR DESCRIPTION
Containers where not correctly deleted when recover_stopped=false is configured.
Also the driver is now less noisy if a container was lost whil nomad client was down.