### PR TITLE
config: Add readonly_rootfs config option like docker plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 * config: Map host devices into container. [[GH-41](https://github.com/hashicorp/nomad-driver-podman/pull/41)]
 * config: Stream logs via API, support journald log driver. [[GH-99](https://github.com/hashicorp/nomad-driver-podman/pull/99)]
 * config: Privileged containers.
+* config: Allow mounting rootfs as read-only. [[GH-133](https://github.com/hashicorp/nomad-driver-podman/pull/133)]
 
 BUG FIXES:
 * log: Use error key context to log errors rather than Go err style. [[GH-126](https://github.com/hashicorp/nomad-driver-podman/pull/126)]

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ config {
 }
 ```
 
-* **devices** - (Optional) A list of `host-device[:container-device][:permissions]` definitions. 
+* **devices** - (Optional) A list of `host-device[:container-device][:permissions]` definitions.
 Each entry adds a host device to the container. Optional permissions can be used to specify device permissions, it is combination of r for read, w for write, and m for mknod(2). See podman documentation for more details.
 
 ```
@@ -416,6 +416,16 @@ config {
   force_pull = true
 }
 ```
+
+* **readonly_rootfs** - (Optional)  true or false (default). Mount the rootfs as read-only.
+
+```
+config {
+  readonly_rootfs = true
+}
+```
+
+
 
 ## Network Configuration
 

--- a/config.go
+++ b/config.go
@@ -74,6 +74,7 @@ var (
 		"tty":                hclspec.NewAttr("tty", "bool", false),
 		"volumes":            hclspec.NewAttr("volumes", "list(string)", false),
 		"force_pull":         hclspec.NewAttr("force_pull", "bool", false),
+		"readonly_rootfs":    hclspec.NewAttr("readonly_rootfs", "bool", false),
 	})
 )
 
@@ -137,4 +138,5 @@ type TaskConfig struct {
 	Tty               bool               `codec:"tty"`
 	ForcePull         bool               `codec:"force_pull"`
 	Privileged        bool               `codec:"privileged"`
+	ReadOnlyRootfs    bool               `codec:"readonly_rootfs"`
 }

--- a/driver.go
+++ b/driver.go
@@ -447,6 +447,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	createOpts.ContainerSecurityConfig.CapDrop = driverConfig.CapDrop
 	createOpts.ContainerSecurityConfig.User = cfg.User
 	createOpts.ContainerSecurityConfig.Privileged = driverConfig.Privileged
+	createOpts.ContainerSecurityConfig.ReadOnlyFilesystem = driverConfig.ReadOnlyRootfs
 
 	// Network config options
 	if cfg.DNS != nil {

--- a/driver_test.go
+++ b/driver_test.go
@@ -1355,6 +1355,15 @@ func TestPodmanDriver_Privileged(t *testing.T) {
 	require.True(t, inspectData.HostConfig.Privileged)
 }
 
+// check enabled readonly_rootfs option
+func TestPodmanDriver_ReadOnlyFilesystem(t *testing.T) {
+	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
+	taskCfg.ReadOnlyRootfs = true
+	inspectData := startDestroyInspect(t, taskCfg, "readonly_rootfs")
+
+	require.True(t, inspectData.HostConfig.ReadonlyRootfs)
+}
+
 // check dns server configuration
 func TestPodmanDriver_Dns(t *testing.T) {
 	if !tu.IsCI() {


### PR DESCRIPTION
This increases the feature parity between docker and podman plugins. Nomad mounts are still successful inside the container.