### PR TITLE
driver: emit a driver event when we pull or load an image

### DIFF
--- a/api/image_inspect.go
+++ b/api/image_inspect.go
@@ -3,10 +3,13 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 )
+
+var ImageNotFound = errors.New("No such Image")
 
 type inspectIDImageResponse struct {
 	Id string `json:"Id"`
@@ -25,6 +28,9 @@ func (c *API) ImageInspectID(ctx context.Context, image string) (string, error) 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return "", err
+	}
+	if res.StatusCode == http.StatusNotFound {
+		return "", ImageNotFound
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/driver.go
+++ b/driver.go
@@ -530,7 +530,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	}
 
 	if !recoverRunningContainer {
-		imageID, err := d.createImage(createOpts.Image, &driverConfig.Auth, driverConfig.ForcePull)
+		imageID, err := d.createImage(createOpts.Image, &driverConfig.Auth, driverConfig.ForcePull, cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create image: %s: %w", createOpts.Image, err)
 		}
@@ -668,7 +668,7 @@ func memoryInBytes(strmem string) (int64, error) {
 
 // Creates the requested image if missing from storage
 // returns the 64-byte image ID as an unique image identifier
-func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool) (string, error) {
+func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool, cfg *drivers.TaskConfig) (string, error) {
 	var imageID string
 	imageName := image
 	// If it is a shortname, we should not have to worry
@@ -688,6 +688,15 @@ func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool) (st
 			archiveData := imageRef.StringWithinTransport()
 			path := strings.Split(archiveData, ":")[0]
 			d.logger.Debug("Load image archive", "path", path)
+			if err = d.eventer.EmitEvent(&drivers.TaskEvent{
+				TaskID:    cfg.ID,
+				TaskName:  cfg.Name,
+				AllocID:   cfg.AllocID,
+				Timestamp: time.Now(),
+				Message:   "Load image " + path,
+			}); err != nil {
+				d.logger.Warn("Unable to emit event", "error", err)
+			}
 			imageName, err = d.podman.ImageLoad(d.ctx, path)
 			if err != nil {
 				return imageID, fmt.Errorf("error while loading image: %w", err)
@@ -696,7 +705,7 @@ func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool) (st
 	}
 
 	imageID, err := d.podman.ImageInspectID(d.ctx, imageName)
-	if err != nil {
+	if err != nil && err != api.ImageNotFound {
 		// If ImageInspectID errors, continue the operation and try
 		// to pull the image instead
 		d.logger.Warn("Unable to check for local image", "image", imageName, "error", err)
@@ -706,7 +715,17 @@ func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool) (st
 		return imageID, nil
 	}
 
-	d.logger.Debug("Pull image", "image", imageName)
+	d.logger.Info("Pull image", "image", imageName)
+	if err = d.eventer.EmitEvent(&drivers.TaskEvent{
+		TaskID:    cfg.ID,
+		TaskName:  cfg.Name,
+		AllocID:   cfg.AllocID,
+		Timestamp: time.Now(),
+		Message:   "Pull image " + imageName,
+	}); err != nil {
+		d.logger.Warn("Unable to emit event", "error", err)
+	}
+
 	imageAuth := api.ImageAuthConfig{
 		Username: auth.Username,
 		Password: auth.Password,

--- a/driver.go
+++ b/driver.go
@@ -688,15 +688,14 @@ func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool, cfg
 			archiveData := imageRef.StringWithinTransport()
 			path := strings.Split(archiveData, ":")[0]
 			d.logger.Debug("Load image archive", "path", path)
-			if err = d.eventer.EmitEvent(&drivers.TaskEvent{
+			//nolint // ignore returned error, can't react in a good way
+			d.eventer.EmitEvent(&drivers.TaskEvent{
 				TaskID:    cfg.ID,
 				TaskName:  cfg.Name,
 				AllocID:   cfg.AllocID,
 				Timestamp: time.Now(),
-				Message:   "Load image " + path,
-			}); err != nil {
-				d.logger.Warn("Unable to emit event", "error", err)
-			}
+				Message:   "Loading image " + path,
+			})
 			imageName, err = d.podman.ImageLoad(d.ctx, path)
 			if err != nil {
 				return imageID, fmt.Errorf("error while loading image: %w", err)
@@ -715,17 +714,15 @@ func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool, cfg
 		return imageID, nil
 	}
 
-	d.logger.Info("Pull image", "image", imageName)
-	if err = d.eventer.EmitEvent(&drivers.TaskEvent{
+	d.logger.Info("Pulling image", "image", imageName)
+	//nolint // ignore returned error, can't react in a good way
+	d.eventer.EmitEvent(&drivers.TaskEvent{
 		TaskID:    cfg.ID,
 		TaskName:  cfg.Name,
 		AllocID:   cfg.AllocID,
 		Timestamp: time.Now(),
-		Message:   "Pull image " + imageName,
-	}); err != nil {
-		d.logger.Warn("Unable to emit event", "error", err)
-	}
-
+		Message:   "Pulling image " + imageName,
+	})
 	imageAuth := api.ImageAuthConfig{
 		Username: auth.Username,
 		Password: auth.Password,

--- a/driver_test.go
+++ b/driver_test.go
@@ -1745,7 +1745,13 @@ func startDestroyInspectImage(t *testing.T, image string, taskName string) {
 
 	d := podmanDriverHarness(t, nil)
 
-	imageID, err := getPodmanDriver(t, d).createImage(image, &AuthConfig{}, false)
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      taskName,
+		AllocID:   uuid.Generate(),
+		Resources: createBasicResources(),
+	}
+	imageID, err := getPodmanDriver(t, d).createImage(image, &AuthConfig{}, false, task)
 	require.NoError(t, err)
 	require.Equal(t, imageID, inspectData.Image)
 }
@@ -1800,7 +1806,13 @@ func Test_createImageArchives(t *testing.T) {
 func createInspectImage(t *testing.T, image, reference string) {
 	d := podmanDriverHarness(t, nil)
 
-	idTest, err := getPodmanDriver(t, d).createImage(image, &AuthConfig{}, false)
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "inspectImage",
+		AllocID:   uuid.Generate(),
+		Resources: createBasicResources(),
+	}
+	idTest, err := getPodmanDriver(t, d).createImage(image, &AuthConfig{}, false, task)
 	require.NoError(t, err)
 
 	idRef, err := getPodmanDriver(t, d).podman.ImageInspectID(context.Background(), reference)


### PR DESCRIPTION
This PR improves logging around long running pull or load operations. Further it emits a driver event before it start to pull or load an image to make a potential slow operation visible in the Nomad UI.