### PR TITLE
Add support for container creation's selinux_opts attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* config: Add `selinux_opts` option [[GH-139](https://github.com/hashicorp/nomad-driver-podman/pull/139)]
 * perf: Use ping api instead of system info for fingerprinting [[GH-186](https://github.com/hashicorp/nomad-driver-podman/pull/186)]
 * runtime: Prevent concurrent image pulls of same imageRef [[GH-159](https://github.com/hashicorp/nomad-driver-podman/pull/159)]
 
@@ -17,7 +18,6 @@ FEATURES:
 * config: Stream logs via API, support journald log driver. [[GH-99](https://github.com/hashicorp/nomad-driver-podman/pull/99)]
 * config: Privileged containers. [[GH-137](https://github.com/hashicorp/nomad-driver-podman/pull/137)]
 * config: Add `cpu_hard_limit` and `cpu_cfs_period` options [[GH-149](https://github.com/hashicorp/nomad-driver-podman/pull/149)]
-* config: Add `selinux_opts` option [[GH-139](https://github.com/hashicorp/nomad-driver-podman/pull/139)]
 * config: Allow mounting rootfs as read-only. [[GH-133](https://github.com/hashicorp/nomad-driver-podman/pull/133)]
 * config: Allow setting `ulimit` configuration. [[GH-166](https://github.com/hashicorp/nomad-driver-podman/pull/166)]
 * config: Allow setting `image_pull_timeout` and `client_http_timeout ` [[GH-131](https://github.com/hashicorp/nomad-driver-podman/pull/131)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ FEATURES:
 * config: Stream logs via API, support journald log driver. [[GH-99](https://github.com/hashicorp/nomad-driver-podman/pull/99)]
 * config: Privileged containers. [[GH-137](https://github.com/hashicorp/nomad-driver-podman/pull/137)]
 * config: Add `cpu_hard_limit` and `cpu_cfs_period` options [[GH-149](https://github.com/hashicorp/nomad-driver-podman/pull/149)]
+* config: Add `selinux_opts` option [[GH-139](https://github.com/hashicorp/nomad-driver-podman/pull/139)]
 * config: Allow mounting rootfs as read-only. [[GH-133](https://github.com/hashicorp/nomad-driver-podman/pull/133)]
 * config: Allow setting `ulimit` configuration. [[GH-166](https://github.com/hashicorp/nomad-driver-podman/pull/166)]
 * config: Allow setting `image_pull_timeout` and `client_http_timeout ` [[GH-131](https://github.com/hashicorp/nomad-driver-podman/pull/131)]

--- a/README.md
+++ b/README.md
@@ -396,6 +396,16 @@ config {
 }
 ```
 
+* **selinux_opts** - (Optional)  A list of process labels the container will use.
+
+```
+config {
+  selinux_opts = [
+    "type:my_container.process"
+  ]
+}
+```
+
 * **sysctl** - (Optional)  A key-value map of sysctl configurations to set to the containers on start.
 
 ```hcl

--- a/api/structs.go
+++ b/api/structs.go
@@ -840,6 +840,11 @@ type InspectContainerHostConfig struct {
 	// capabilities listed in the container's spec, compared against a set
 	// of default capabilities.
 	CapDrop []string `json:"CapDrop"`
+	// SelinuxProcessLabel is the process label the container will use.
+	// If SELinux is enabled and this is not specified, a label will be
+	// automatically generated if not specified.
+	// Optional.
+	SelinuxOpts []string `json:"SelinuxOpts"`
 	// Dns is a list of DNS nameservers that will be added to the
 	// container's resolv.conf
 	Dns []string `json:"Dns"`

--- a/config.go
+++ b/config.go
@@ -52,6 +52,7 @@ var (
 		"command":        hclspec.NewAttr("command", "string", false),
 		"cap_add":        hclspec.NewAttr("cap_add", "list(string)", false),
 		"cap_drop":       hclspec.NewAttr("cap_drop", "list(string)", false),
+		"selinux_opts":   hclspec.NewAttr("selinux_opts", "list(string)", false),
 		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
 		"cpu_cfs_period": hclspec.NewAttr("cpu_cfs_period", "number", false),
 		"devices":        hclspec.NewAttr("devices", "list(string)", false),
@@ -130,6 +131,7 @@ type TaskConfig struct {
 	Volumes           []string           `codec:"volumes"`
 	CapAdd            []string           `codec:"cap_add"`
 	CapDrop           []string           `codec:"cap_drop"`
+	SelinuxOpts       []string           `codec:"selinux_opts"`
 	Command           string             `codec:"command"`
 	Devices           []string           `codec:"devices"`
 	Entrypoint        string             `codec:"entrypoint"`

--- a/driver.go
+++ b/driver.go
@@ -484,6 +484,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	// Security config options
 	createOpts.ContainerSecurityConfig.CapAdd = driverConfig.CapAdd
 	createOpts.ContainerSecurityConfig.CapDrop = driverConfig.CapDrop
+	createOpts.ContainerSecurityConfig.SelinuxOpts = driverConfig.SelinuxOpts
 	createOpts.ContainerSecurityConfig.User = cfg.User
 	createOpts.ContainerSecurityConfig.Privileged = driverConfig.Privileged
 	createOpts.ContainerSecurityConfig.ReadOnlyFilesystem = driverConfig.ReadOnlyRootfs

--- a/driver_test.go
+++ b/driver_test.go
@@ -1336,7 +1336,16 @@ func TestPodmanDriver_DefaultCaps(t *testing.T) {
 	require.Contains(t, inspectData.EffectiveCaps, "CAP_CHOWN")
 }
 
-// check modified capabilities (CapAdd/CapDrop)
+// check default process label
+func TestPodmanDriver_DefaultProcessLabel(t *testing.T) {
+	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
+	inspectData := startDestroyInspect(t, taskCfg, "defaultprocesslabel")
+
+	// a default container gets "disable" process label
+	require.Contains(t, inspectData.ProcessLabel, "label=disable")
+}
+
+// check modified capabilities (CapAdd/CapDrop/SelinuxOpts)
 func TestPodmanDriver_Caps(t *testing.T) {
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	// 	cap_add = [
@@ -1347,6 +1356,10 @@ func TestPodmanDriver_Caps(t *testing.T) {
 	//     "MKNOD",
 	//   ]
 	taskCfg.CapDrop = []string{"CHOWN"}
+	// 	selinux_opts = [
+	//     "disable",
+	//   ]
+	taskCfg.SelinuxOpts = []string{"disable"}
 
 	inspectData := startDestroyInspect(t, taskCfg, "caps")
 
@@ -1354,6 +1367,8 @@ func TestPodmanDriver_Caps(t *testing.T) {
 	require.Contains(t, inspectData.EffectiveCaps, "CAP_SYS_TIME")
 	// we dropped CAP_CHOWN, so we should NOT see it in inspect
 	require.NotContains(t, inspectData.EffectiveCaps, "CAP_CHOWN")
+	// we added "disable" process label, so we should see it in inspect
+	require.Contains(t, inspectData.ProcessLabel, "label=disable")
 }
 
 // check enabled tty option


### PR DESCRIPTION
Solves #135 

Hi!

This PR adds support for the selinux_opts attribute, as per https://docs.podman.io/en/latest/_static/api.html#operation/ContainerCreateLibpod .

I've also updated the README file and the tests to support the new attribute.

Thank you!