### PR TITLE
update Vagrantfile and VM test instructions

### DIFF
--- a/.github/machinesetup.sh
+++ b/.github/machinesetup.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+# Update ca-certificates first to prevent using outdated certificates for the
+# podman repository.
+# https://github.com/containers/podman/issues/8533#issuecomment-944873690
+apt-get update
+apt-get install -y ca-certificates
+
 # add podman repository
 echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/Release.key | apt-key add -
@@ -9,7 +15,7 @@ curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/
 apt-get update || true
 
 # install podman for running the test suite
-apt-get install -y podman wget ca-certificates build-essential
+apt-get install -y podman wget build-essential
 
 # get catatonit (to check podman --init switch)
 cd /tmp
@@ -25,7 +31,7 @@ podman info
 echo "====== Podman version:"
 podman version
 
-# enable http socket 
+# enable http socket
 cat > /etc/systemd/system/podman.service << EOF
 [Unit]
 Description=Podman API Service

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ config {
 }
 ```
 
-* **devices** - (Optional) A list of `host-device[:container-device][:permissions]` definitions. 
+* **devices** - (Optional) A list of `host-device[:container-device][:permissions]` definitions.
 Each entry adds a host device to the container. Optional permissions can be used to specify device permissions, it is combination of r for read, w for write, and m for mknod(2). See podman documentation for more details.
 
 ```
@@ -549,7 +549,11 @@ vagrant up
 
 # ssh into the vm
 vagrant ssh
+````
 
+Running a Nomad dev agent with the Podman plugin:
+
+```
 # Build the task driver plugin
 sudo -E ./build.sh
 
@@ -569,4 +573,14 @@ nomad job run examples/redis_ports.nomad
 nomad job status redis
 
 sudo podman ps
+```
+
+Running the tests:
+
+```
+# Start the Podman server
+systemctl --user start podman.socket
+
+# Run the tests
+CI=1 ./build/bin/gotestsum --junitfile ./build/test/result.xml -- -timeout=15m . ./api
 ```


### PR DESCRIPTION
The OpenSuse registry CA certificates need to be updated before adding it to `apt`.

I also added the commands that need to be executed for running tests following what's set in the GitHub Action.