### PR TITLE
feat: append nomad task mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * config: Privileged containers.
 * config: Add `cpu_hard_limit` and `cpu_cfs_period` options [[GH-149](https://github.com/hashicorp/nomad-driver-podman/pull/149)]
 * config: Allow mounting rootfs as read-only. [[GH-133](https://github.com/hashicorp/nomad-driver-podman/pull/133)]
+* volume: Add host volumes support for `volume_mount` Stanza [[GH-152](https://github.com/hashicorp/nomad-driver-podman/pull/152)]
 
 BUG FIXES:
 * log: Use error key context to log errors rather than Go err style. [[GH-126](https://github.com/hashicorp/nomad-driver-podman/pull/126)]

--- a/driver.go
+++ b/driver.go
@@ -1099,6 +1099,19 @@ func (d *Driver) containerMounts(task *drivers.TaskConfig, driverConfig *TaskCon
 		binds = append(binds, bind)
 	}
 
+	// append nomad task mounts
+	for _, mnt := range task.Mounts {
+		bind := spec.Mount{
+			Source:      mnt.HostPath,
+			Destination: mnt.TaskPath,
+			Type:        "bind",
+		}
+		if mnt.Readonly {
+			bind.Options = []string{"ro"}
+		}
+		binds = append(binds, bind)
+	}
+
 	return binds, nil
 }
 


### PR DESCRIPTION

something like this: https://github.com/hashicorp/waypoint/blob/566c65afb74fcfe64f3f0e50ef7eddbd03d9a3c8/internal/serverinstall/nomad.go#L914

will always fail when using the podman driver, because the driver does not handle this mounts now.

this PR fixup it