### PR TITLE
Fix broken go-discover dep tree. 

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,5 +17,5 @@ deps: ## Install dependencies
 	@echo "==> Installing dependencies..."
 	cd tools && GOBIN=$(CURDIR)/build/bin go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 	cd tools && GOBIN=$(CURDIR)/build/bin go get github.com/client9/misspell/cmd/misspell@v0.3.4
-	cd tools && GOBIN=$(CURDIR)/build/bin go get github.com/hashicorp/go-hclog/hclogvet@master 
+	cd tools && GOBIN=$(CURDIR)/build/bin go get github.com/hashicorp/go-hclog/hclogvet@main
 	cd tools && GOBIN=$(CURDIR)/build/bin go get gotest.tools/gotestsum

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 replace (
 	github.com/docker/docker v1.13.1 => github.com/docker/docker v0.7.3-0.20181219122643-d1117e8e1040
 	github.com/godbus/dbus => github.com/godbus/dbus v5.0.1+incompatible
+	github.com/hashicorp/go-discover => github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192
 
 	github.com/opencontainers/runc v0.1.1 => github.com/opencontainers/runc v1.0.0-rc2.0.20181210164344-f5b99917df9f
 	launchpad.net/gocheck => github.com/go-check/check v0.0.0-20140225173054-eb6ee6f84d0a

--- a/go.sum
+++ b/go.sum
@@ -515,6 +515,8 @@ github.com/hashicorp/go-connlimit v0.3.0/go.mod h1:OUj9FGL1tPIhl/2RCfzYHrIiWj+VV
 github.com/hashicorp/go-cty-funcs v0.0.0-20200930094925-2721b1e36840/go.mod h1:Abjk0jbRkDaNCzsRhOv2iDCofYpX1eVsjozoiK63qLA=
 github.com/hashicorp/go-discover v0.0.0-20191202160150-7ec2cfbda7a2/go.mod h1:NnH5X4UCBEBdTuK2L8s4e4ilJm3UmGX0bANHCz0HSs0=
 github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f/go.mod h1:D4eo8/CN92vm9/9UDG+ldX1/fMFa4kpl8qzyTolus8o=
+github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192 h1:eje2KOX8Sf7aYPiAsLnpWdAIrGRMcpFjN/Go/Exb7Zo=
+github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192/go.mod h1:3/4dzY4lR1Hzt9bBqMhBzG7lngZ0GKx/nL6G/ad62wE=
 github.com/hashicorp/go-envparse v0.0.0-20180119215841-310ca1881b22 h1:HTmDIaSN95gbdMyrsbNiXSdW4fbGctGQwEqv0H7OhDQ=
 github.com/hashicorp/go-envparse v0.0.0-20180119215841-310ca1881b22/go.mod h1:/NlxCzN2D4C4L2uDE6ux/h6jM+n98VFQM14nnCIfHJU=
 github.com/hashicorp/go-gatedio v0.5.0 h1:Jm1X5yP4yCqqWj5L1TgW7iZwCVPGtVc+mro5r/XX7Tg=
@@ -956,6 +958,7 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtse
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.83+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.24.0
-	github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20210914162113-e5a68744f479
+	github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20220110220524-e77830785dbe
 	gotest.tools/gotestsum v1.7.0
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -141,6 +141,8 @@ github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20210108181059-a2184e57a2d4 h1:e
 github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20210108181059-a2184e57a2d4/go.mod h1:f0uAs1kAopX4JXFgR4kMixWftM8qLha6edaFVawdNtg=
 github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20210914162113-e5a68744f479 h1:51VbEy2gQJq5N9Ajh1JqxCBxTnSyX4lM+VIqNMkdtzM=
 github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20210914162113-e5a68744f479/go.mod h1:f0uAs1kAopX4JXFgR4kMixWftM8qLha6edaFVawdNtg=
+github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20220110220524-e77830785dbe h1:3B+hw+vJosD5EjWZAAr9gzxPK3PB+i8L15bnFikPFl0=
+github.com/hashicorp/go-hclog/hclogvet v0.1.4-0.20220110220524-e77830785dbe/go.mod h1:f0uAs1kAopX4JXFgR4kMixWftM8qLha6edaFVawdNtg=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -366,6 +368,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
The go-discover mod had some broken deps (https://github.com/hashicorp/go-discover/issues/172) so this PR fixes that issue and updates hclogvet's branch to main. 

Without these changes, anyone building with a clean GOPATH will have a very broken dependency tree. 

