### PR TITLE
Prevent concurrent image pulls of same imageRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+
+* runtime: Prevent concurrent image pulls of same imageRef [[GH-159](https://github.com/hashicorp/nomad-driver-podman/pull/159)]
+
 ## 0.4.0 (July 14, 2022)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/nomad/api v0.0.0-20220519231241-2b054e38e91a
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/stretchr/testify v1.7.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 require (


### PR DESCRIPTION
podman does not establish a lock when it pulls an image. 

There is some movement towards a more efficient implementation via https://github.com/containers/podman/issues/1911
Other people workaround this problem by having a lock in another layer like e.g. https://github.com/cri-o/cri-o/pull/3409

This PR adds such a mechanism to nomad-driver-podman. It prevents to pull the same image on the same host concurrently. A good, manual, check is to run a job with e.g. 5x redis and to ensure that the image is locally not available. First allocation will pull the image, 4 others will wait until it is ready. Without this PR we would try to download it 5 times parallel, wasting time and bandwith.

There is no unit test because i could not figure out a good way to code it. Maybe i can get a recommandation?

