### PR TITLE
config: Add ulimit option like docker driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * config: Privileged containers.
 * config: Add `cpu_hard_limit` and `cpu_cfs_period` options [[GH-149](https://github.com/hashicorp/nomad-driver-podman/pull/149)]
 * config: Allow mounting rootfs as read-only. [[GH-133](https://github.com/hashicorp/nomad-driver-podman/pull/133)]
+* config: Allow setting ulimit configuration.
 
 BUG FIXES:
 * log: Use error key context to log errors rather than Go err style. [[GH-126](https://github.com/hashicorp/nomad-driver-podman/pull/126)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 * config: Privileged containers.
 * config: Add `cpu_hard_limit` and `cpu_cfs_period` options [[GH-149](https://github.com/hashicorp/nomad-driver-podman/pull/149)]
 * config: Allow mounting rootfs as read-only. [[GH-133](https://github.com/hashicorp/nomad-driver-podman/pull/133)]
-* config: Allow setting ulimit configuration.
+* config: Allow setting `ulimit` configuration. [[GH-166](https://github.com/hashicorp/nomad-driver-podman/pull/166)]
 
 BUG FIXES:
 * log: Use error key context to log errors rather than Go err style. [[GH-126](https://github.com/hashicorp/nomad-driver-podman/pull/126)]

--- a/README.md
+++ b/README.md
@@ -425,6 +425,15 @@ config {
 }
 ```
 
+* **ulimit** - (Optional) A key-value map of ulimit configurations to set to the containers to start.
+```hcl
+config {
+  ulimit {
+    nproc = "4242"
+    nofile = "2048:4096"
+  }
+}
+```
 
 
 ## Network Configuration

--- a/config.go
+++ b/config.go
@@ -74,6 +74,7 @@ var (
 		"sysctl":             hclspec.NewAttr("sysctl", "list(map(string))", false),
 		"tmpfs":              hclspec.NewAttr("tmpfs", "list(string)", false),
 		"tty":                hclspec.NewAttr("tty", "bool", false),
+		"ulimit":             hclspec.NewAttr("ulimit", "list(map(string))", false),
 		"volumes":            hclspec.NewAttr("volumes", "list(string)", false),
 		"force_pull":         hclspec.NewAttr("force_pull", "bool", false),
 		"readonly_rootfs":    hclspec.NewAttr("readonly_rootfs", "bool", false),
@@ -137,6 +138,7 @@ type TaskConfig struct {
 	MemorySwappiness  int64              `codec:"memory_swappiness"`
 	PortMap           hclutils.MapStrInt `codec:"port_map"`
 	Sysctl            hclutils.MapStrStr `codec:"sysctl"`
+	Ulimit            hclutils.MapStrStr `codec:"ulimit"`
 	CPUHardLimit      bool               `codec:"cpu_hard_limit"`
 	Init              bool               `codec:"init"`
 	Tty               bool               `codec:"tty"`


### PR DESCRIPTION
I guess the title is self-explanatory. 

The `sliceMergeUlimit` function is adapted from the nomad [docker driver](https://github.com/hashicorp/nomad/blob/main/drivers/docker/driver.go#L1723)