### PR TITLE
support host/CSI volumes and using podman tasks as CSI plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * config: Privileged containers.
 * config: Add `cpu_hard_limit` and `cpu_cfs_period` options [[GH-149](https://github.com/hashicorp/nomad-driver-podman/pull/149)]
 * config: Allow mounting rootfs as read-only. [[GH-133](https://github.com/hashicorp/nomad-driver-podman/pull/133)]
+* runtime: Add support for host and CSI volumes and using podman tasks as CSI plugins [[GH-169](https://github.com/hashicorp/nomad-driver-podman/pull/169)]
 
 BUG FIXES:
 * log: Use error key context to log errors rather than Go err style. [[GH-126](https://github.com/hashicorp/nomad-driver-podman/pull/126)]

--- a/driver.go
+++ b/driver.go
@@ -1084,6 +1084,19 @@ func (d *Driver) containerMounts(task *drivers.TaskConfig, driverConfig *TaskCon
 		binds = append(binds, bind)
 	}
 
+	// create binds for host volumes, CSI plugins, and CSI volumes
+	for _, m := range task.Mounts {
+		bind := spec.Mount{
+			Type:        "bind",
+			Destination: m.TaskPath,
+			Source:      m.HostPath,
+		}
+		if m.Readonly {
+			bind.Options = append(bind.Options, "ro")
+		}
+		binds = append(binds, bind)
+	}
+
 	if selinuxLabel := d.config.Volumes.SelinuxLabel; selinuxLabel != "" {
 		// Apply SELinux Label to each volume
 		for i := range binds {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad-driver-podman/issues/168. 

Tested running a job as both a CSI plugin and with a host volume:

<details><summary>jobspec</summary>

```hcl
job "hostpath" {
  datacenters = ["dc1"]

  group "plugins" {

    volume "host_data" {
      type      = "host"
      read_only = false
      source    = "shared_data"
    }

    task "plugin" {
      driver = "podman"
      config {
        image = "quay.io/k8scsi/hostpathplugin:v1.2.0"
        args = [
          "--drivername=csi-hostpath",
          "--v=5",
          "--endpoint=${CSI_ENDPOINT}",
          "--nodeid=node-${NOMAD_ALLOC_INDEX}",
        ]

        cap_add = ["SYS_ADMIN"]
      }

      csi_plugin {
        id        = "hostpath-plugin0"
        type      = "monolith"
        mount_dir = "/csi"
      }

      volume_mount {
        volume      = "host_data"
        destination = "/host_data"
        read_only   = false
      }

      resources {
        cpu    = 256
        memory = 128
      }
    }
  }
}

```

</details>

Working host volume:

```
$ nomad alloc exec 8c01 ls /host_data
example.txt
```

Working CSI plugin:

```
$ nomad plugin status hostpath
ID                   = hostpath-plugin0
Provider             = csi-hostpath
Version              = v1.2.0-0-g83590990
Controllers Healthy  = 1
Controllers Expected = 1
Nodes Healthy        = 1
Nodes Expected       = 1

Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
8c012686  c53f3ea2  plugins     0        run      running  16s ago  4s ago

$ nomad volume create ./hostpath.hcl
Created external volume a395c7f1-d7a8-11ec-bc8c-1eac4d1b7ed8 with ID VOLUME_NAME

$ nomad volume status VOLUME_NAME
ID                   = VOLUME_NAME
Name                 = VOLUME_NAME
External ID          = a395c7f1-d7a8-11ec-bc8c-1eac4d1b7ed8
Plugin ID            = hostpath-plugin0
Provider             = csi-hostpath
Version              = v1.2.0-0-g83590990
Schedulable          = true
Controllers Healthy  = 1
Controllers Expected = 1
Nodes Healthy        = 1
Nodes Expected       = 1
Access Mode          = <none>
Attachment Mode      = <none>
Mount Options        = flags: [REDACTED]
Namespace            = default

Topologies
Topology  Segments
01        topology.hostpath.csi/node=node-0

Allocations
No allocations placed
```