### PR TITLE
Rdx 386 set codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # Blanket ownership of all PRs.
 * @jazzyfresh @jrasell @lgfa29 @towe75
+
+# release configuration
+/.release/                              @hashicorp/release-engineering @hashicorp/hc-github-team-nomad-ecosystem
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/hc-github-team-nomad-ecosystem

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 * @jazzyfresh @jrasell @lgfa29 @towe75
 
 # release configuration
-/.release/                              @hashicorp/release-engineering @hashicorp/hc-github-team-nomad-ecosystem
-/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/hc-github-team-nomad-ecosystem
+/.release/                              @hashicorp/release-engineering 
+/.github/workflows/build.yml            @hashicorp/release-engineering 


### PR DESCRIPTION
Locks down changes to release directories so that they require approval from release engineering, and so they have service account rights for pipeline runs and backport-assistant functionality.