### PR TITLE
build: add arm arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         goos: ["linux"]
-        goarch: ["amd64", "arm64"]
+        goarch: ["amd64", "arm64", "arm"]
       fail-fast: true
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build


### PR DESCRIPTION
Add support for `arm` architecture. While we don't actively test it yet, adding it now will trigger this during the nightly builds for a while where the community can test it until the next releases.

Closes #178