### PR TITLE
enable building rpm and deb through github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,35 @@ jobs:
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+
+      - name: Package
+        uses: flowpoint/actions-packaging-linux@v1.6
+        with:
+          name: ${{ env.PKG_NAME }}
+          description: "A nomad taskdriver for podman containers"
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/nomad-driver-podman"
+          license: "MPL-2.0"
+            #binary: "pkg/${{ matrix.goos }}_${{ matrix.goarch }}/${{ env.PKG_NAME }}"
+          deb_depends: "openssl podman"
+          rpm_depends: "openssl podman"
+          config_dir: ".release/linux/package/"
+          preinstall: ".release/linux/preinst"
+
+      - name: Set Package Names
+        run: |
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.RPM_PACKAGE }}
+          path: out/${{ env.RPM_PACKAGE }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.DEB_PACKAGE }}
+          path: out/${{ env.DEB_PACKAGE }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nomad-driver-podman
 pkg/
 .vagrant
 *.log
+.release/linux/package/opt/nomad/plugins/nomad-driver-podman

--- a/.release/linux/preinst
+++ b/.release/linux/preinst
@@ -1,0 +1,1 @@
+mkdir -p /opt/nomad/plugins

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,7 +45,8 @@ deps: ## Install build dependencies
 .PHONY: clean
 clean: ## Cleanup previous build
 	@echo "==> Cleanup previous build"
-	rm -f ./build/nomad-driver-podman
+	rm -rf ./pkg
+	rm -rf .release/linux/package/opt/nomad/plugins/*
 
 pkg/%/nomad-driver-podman: GO_OUT ?= $@
 pkg/%/nomad-driver-podman: ## Build the nomad-driver-podman plugin for GOOS_GOARCH, e.g. pkg/linux_amd64/nomad-driver-podman
@@ -54,6 +55,10 @@ pkg/%/nomad-driver-podman: ## Build the nomad-driver-podman plugin for GOOS_GOAR
 		GOOS=$(firstword $(subst _, ,$*)) \
 		GOARCH=$(lastword $(subst _, ,$*)) \
 		go build -trimpath -o $(GO_OUT)
+	mkdir -p .release/linux/package/opt/nomad/plugins/
+	cp -v $(CURDIR)/$@ $(CURDIR)/.release/linux/package/opt/nomad/plugins/nomad-driver-podman
+
+##-$(firstword $(subst _, ,$*)).$(lastword $(subst _, ,$*))
 
 .PRECIOUS: pkg/%/nomad-driver-podman
 pkg/%.zip: pkg/%/nomad-driver-podman ## Build and zip the nomad-driver-podman plugin for GOOS_GOARCH, e.g. pkg/linux_amd64.zip


### PR DESCRIPTION
Hi there,
it seemed like there aren't yet packages for the podman driver.
it would be a nice to have in your yum and deb repos, like https://rpm.releases.hashicorp.com/fedora/hashicorp.repo](https://rpm.releases.hashicorp.com/fedora/hashicorp.repo)

i hope this pr is a start.
this might also be a solution for  #176

i tried to match your release setup from [the nomad repo](https://github.com/hashicorp/nomad).
however, [hashicorp/actions-packaging-linux](https://github.com/hashicorp/actions-packaging-linux) expects there to be a binary and installs it only **/usr/bin**.
i lifted this requirement in my temporary fork, see: [flowpoint/actions-packaging-linux](https://github.com/flowpoint/actions-packaging-linux) and opened [https://github.com/hashicorp/actions-packaging-linux/pull/7](https://github.com/hashicorp/actions-packaging-linux/pull/7)

comments appreciated
greetings