### PR TITLE
fix container stats endpoint response handling

### DIFF
--- a/api/container_stats.go
+++ b/api/container_stats.go
@@ -38,6 +38,12 @@ func (c *API) ContainerStats(ctx context.Context, name string) (Stats, error) {
 	if err != nil {
 		return stats, err
 	}
+
+	// Since podman 4.1.1, an empty 200 response is returned for stopped containers.
+	if len(body) == 0 {
+		return stats, ContainerNotFound
+	}
+
 	err = json.Unmarshal(body, &stats)
 	if err != nil {
 		return stats, err


### PR DESCRIPTION
Podman 4.1.1 changed the `stats` endpoint's HTTP status for stopped containers from 404 to 200.

Fixes #182
Closes #187