### PR TITLE
Use ping api instead of system info for fingerprinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+* perf: Use ping api instead of system info for fingerprinting [[GH-186](https://github.com/hashicorp/nomad-driver-podman/pull/186)]
 * runtime: Prevent concurrent image pulls of same imageRef [[GH-159](https://github.com/hashicorp/nomad-driver-podman/pull/159)]
 
 ## 0.4.0 (July 14, 2022)

--- a/api/ping.go
+++ b/api/ping.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// Ping podman service
+// Return lipod api version
+func (c *API) Ping(ctx context.Context) (string, error) {
+
+	res, err := c.Get(ctx, "/libpod/_ping")
+	if err != nil {
+		return "", err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cannot ping Podman api, status code: %d", res.StatusCode)
+	}
+	version := res.Header.Get("Libpod-API-Version")
+	if version == "" {
+		return "", fmt.Errorf("Unable to get libpod api version from response header")
+	}
+	return version, nil
+}

--- a/driver.go
+++ b/driver.go
@@ -223,38 +223,54 @@ func (d *Driver) handleFingerprint(ctx context.Context, ch chan<- *drivers.Finge
 }
 
 func (d *Driver) buildFingerprint() *drivers.Fingerprint {
-	var health drivers.HealthState
-	var desc string
 	attrs := map[string]*pstructs.Attribute{}
 
-	// be negative and guess that we will not be able to get a podman connection
-	health = drivers.HealthStateUndetected
-	desc = "disabled"
-
-	// try to connect and get version info
-	info, err := d.podman.SystemInfo(d.ctx)
-	if err != nil {
-		d.logger.Error("Could not get podman info", "error", err)
-	} else {
-		// yay! we can enable the driver
-		health = drivers.HealthStateHealthy
-		desc = "ready"
-		attrs["driver.podman"] = pstructs.NewBoolAttribute(true)
-		attrs["driver.podman.version"] = pstructs.NewStringAttribute(info.Version.Version)
-		attrs["driver.podman.rootless"] = pstructs.NewBoolAttribute(info.Host.Security.Rootless)
-		attrs["driver.podman.cgroupVersion"] = pstructs.NewStringAttribute(info.Host.CGroupsVersion)
-		if d.systemInfo.Version.Version == "" {
-			// keep first received systemInfo in driver struct
-			// it is used to toggle cgroup v1/v2, rootless/rootful behavior
-			d.systemInfo = info
-			d.cgroupV2 = info.Host.CGroupsVersion == "v2"
+	// Ping podman api
+	version, err := d.podman.Ping(d.ctx)
+	if err != nil || version == "" {
+		// not reachable?
+		// deactivate driver, forget podman details
+		d.systemInfo = api.Info{}
+		d.logger.Error("Could not get podman version", "error", err)
+		return &drivers.Fingerprint{
+			Attributes:        attrs,
+			Health:            drivers.HealthStateUndetected,
+			HealthDescription: "disabled",
 		}
+	} else {
+
+		// it's reachable
+
+		// do we already know details about podman or is the version different?
+		if d.systemInfo.Version.APIVersion != version {
+			// no? then fetch and cache it
+			// try to connect and get version info
+			info, err := d.podman.SystemInfo(d.ctx)
+			if err != nil {
+				d.logger.Error("Could not get podman info", "error", err)
+				return &drivers.Fingerprint{
+					Attributes:        attrs,
+					Health:            drivers.HealthStateUndetected,
+					HealthDescription: "disabled",
+				}
+			} else {
+				// keep first received systemInfo in driver struct
+				// it is used to toggle cgroup v1/v2, rootless/rootful behavior
+				d.systemInfo = info
+				d.cgroupV2 = info.Host.CGroupsVersion == "v2"
+			}
+		}
+
+		attrs["driver.podman"] = pstructs.NewBoolAttribute(true)
+		attrs["driver.podman.version"] = pstructs.NewStringAttribute(version)
+		attrs["driver.podman.rootless"] = pstructs.NewBoolAttribute(d.systemInfo.Host.Security.Rootless)
+		attrs["driver.podman.cgroupVersion"] = pstructs.NewStringAttribute(d.systemInfo.Host.CGroupsVersion)
 	}
 
 	return &drivers.Fingerprint{
 		Attributes:        attrs,
-		Health:            health,
-		HealthDescription: desc,
+		Health:            drivers.HealthStateHealthy,
+		HealthDescription: "ready",
 	}
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -96,6 +96,13 @@ func podmanDriverHarness(t *testing.T, cfg map[string]interface{}) *dtestutil.Dr
 	return harness
 }
 
+func TestPodmanDriver_PingPodman(t *testing.T) {
+	d := podmanDriverHarness(t, nil)
+	version, err := getPodmanDriver(t, d).podman.Ping(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, version)
+}
+
 func TestPodmanDriver_Start_NoImage(t *testing.T) {
 	if !tu.IsCI() {
 		t.Parallel()


### PR DESCRIPTION
## Overview

All nomad drivers must implement a fingerprint mechanism. Back at the day i went with the system info api call and it worked well.  

But it turned out that this is a rather heavy invocation, going even down to the package manager level (dpkg, rpm) to gather informations. The driver builds a fingerprint each 30 seconds and thus it wastes quite some cpu cycles and has an impact on the overall machine load.

## Some numbers

A simple `perf stat` on my machine shows the difference between the two podman cli equivalents:

```
 Performance counter stats for 'podman info':

            240.46 msec task-clock                #    0.721 CPUs utilized
             1,481      context-switches          #    6.159 K/sec
               141      cpu-migrations            #  586.383 /sec
            18,851      page-faults               #   78.397 K/sec

       0.333681791 seconds time elapsed

       0.098392000 seconds user
       0.172141000 seconds sys
```

```
 Performance counter stats for 'podman version':

             60.49 msec task-clock                #    0.426 CPUs utilized
               720      context-switches          #   11.903 K/sec
                74      cpu-migrations            #    1.223 K/sec
             4,449      page-faults               #   73.549 K/sec

       0.141960043 seconds time elapsed

       0.036505000 seconds user
       0.047359000 seconds sys
```

## What the PR does

This PR changes the mechanism to use the _ping api call which is not so resource intensive. System info is now usually  only called once. 

## Conclusion

You will not see a big performance different on a crowded host but it certainly makes the situation better on a idle machine.
