### PR TITLE
fix: podman v4.1.1 or newer version stats api

### DIFF
--- a/api/container_stats.go
+++ b/api/container_stats.go
@@ -30,6 +30,7 @@ func (c *API) ContainerStats(ctx context.Context, name string) (Stats, error) {
 	if res.StatusCode == http.StatusConflict {
 		return stats, ContainerWrongState
 	}
+
 	if res.StatusCode != http.StatusOK {
 		return stats, fmt.Errorf("cannot get stats of container, status code: %d", res.StatusCode)
 	}
@@ -38,6 +39,12 @@ func (c *API) ContainerStats(ctx context.Context, name string) (Stats, error) {
 	if err != nil {
 		return stats, err
 	}
+
+	// podman v4.1.1 or newer version will return 200 code and empty body if the container is exited
+	if len(body) == 0 {
+		return stats, ContainerWrongState
+	}
+
 	err = json.Unmarshal(body, &stats)
 	if err != nil {
 		return stats, err


### PR DESCRIPTION
podman v4.1.1 or newer version will return 200 code and empty body if the container is exited

which will cause nomad nerver got notified even if the container exited with 0

when using lifecycle, the leader task will wait forerver because nomad think the sidecar=false container is still running
due to podman did not report the state to nomad.

for old podman version, it will return `http.StatusConflict` 409, so this fallback fixup is OK to the old version.

Refs: https://github.com/containers/podman/issues/14498

https://github.com/containers/podman/issues/15218