### PR TITLE
config: Set custom apparmor profile or disable apparmor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+FEATURES:
+
+* config: Set custom apparmor profile or disable apparmor. [[GH-188](https://github.com/hashicorp/nomad-driver-podman/pull/188)]
+
 IMPROVEMENTS:
 
 * perf: Use ping api instead of system info for fingerprinting [[GH-186](https://github.com/hashicorp/nomad-driver-podman/pull/186)]

--- a/README.md
+++ b/README.md
@@ -419,6 +419,14 @@ config {
 }
 ```
 
+* **apparmor_profile** - (Optional) Name of a apparmor profile to be used instead of the default profile. The special value `unconfined` disables apparmor for this container:
+
+```
+config {
+  apparmor_profile = "your-profile"
+}
+```
+
 * **force_pull** - (Optional)  true or false (default). Always pull the latest image on container start.
 
 ```hcl

--- a/config.go
+++ b/config.go
@@ -43,7 +43,8 @@ var (
 	// taskConfigSpec is the hcl specification for the driver config section of
 	// a task within a job. It is returned in the TaskConfigSchema RPC
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
-		"args": hclspec.NewAttr("args", "list(string)", false),
+		"apparmor_profile": hclspec.NewAttr("apparmor_profile", "string", false),
+		"args":             hclspec.NewAttr("args", "list(string)", false),
 		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"username": hclspec.NewAttr("username", "string", false),
 			"password": hclspec.NewAttr("password", "string", false),
@@ -121,6 +122,7 @@ type PluginConfig struct {
 
 // TaskConfig is the driver configuration of a task within a job
 type TaskConfig struct {
+	ApparmorProfile   string             `codec:"apparmor_profile"`
 	Args              []string           `codec:"args"`
 	Auth              AuthConfig         `codec:"auth"`
 	Ports             []string           `codec:"ports"`

--- a/driver.go
+++ b/driver.go
@@ -487,6 +487,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	createOpts.ContainerSecurityConfig.User = cfg.User
 	createOpts.ContainerSecurityConfig.Privileged = driverConfig.Privileged
 	createOpts.ContainerSecurityConfig.ReadOnlyFilesystem = driverConfig.ReadOnlyRootfs
+	createOpts.ContainerSecurityConfig.ApparmorProfile = driverConfig.ApparmorProfile
 
 	// Network config options
 	if cfg.DNS != nil {

--- a/driver_test.go
+++ b/driver_test.go
@@ -1367,6 +1367,35 @@ func TestPodmanDriver_Privileged(t *testing.T) {
 	require.True(t, inspectData.HostConfig.Privileged)
 }
 
+// check apparmor default value
+func TestPodmanDriver_AppArmorDefault(t *testing.T) {
+	d := podmanDriverHarness(t, nil)
+
+	// Skip test if apparmor is not available
+	if !getPodmanDriver(t, d).systemInfo.Host.Security.AppArmorEnabled {
+		t.Skip("Skipping AppArmor test ")
+	}
+
+	defaultCfg := newTaskConfig("", busyboxLongRunningCmd)
+	defaultInspectResult := startDestroyInspect(t, defaultCfg, "aa-default")
+	require.Contains(t, defaultInspectResult.AppArmorProfile, "containers-default")
+}
+
+// check apparmor option
+func TestPodmanDriver_AppArmorUnconfined(t *testing.T) {
+	d := podmanDriverHarness(t, nil)
+
+	// Skip test if apparmor is not available
+	if !getPodmanDriver(t, d).systemInfo.Host.Security.AppArmorEnabled {
+		t.Skip("Skipping AppArmor test ")
+	}
+
+	unconfinedCfg := newTaskConfig("", busyboxLongRunningCmd)
+	unconfinedCfg.ApparmorProfile = "unconfined"
+	unconfinedInspectResult := startDestroyInspect(t, unconfinedCfg, "aa-unconfined")
+	require.Equal(t, "unconfined", unconfinedInspectResult.AppArmorProfile)
+}
+
 // check ulimit option
 func TestPodmanDriver_Ulimit(t *testing.T) {
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)


### PR DESCRIPTION
Sometimes `--privileged` is too much and capabilities are not enough. This configuration option allow you to set a custom apparmor profile for a container to e.g. get elevated `/proc` permissions. It can also effectively disable apparmor by setting the value to `unconfined`. 
