### PR TITLE
Fix logic on volume SELinux labels

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -1179,7 +1179,7 @@ func (d *Driver) containerMounts(task *drivers.TaskConfig, driverConfig *TaskCon
 		binds = append(binds, bind)
 	}
 
-	if selinuxLabel := d.config.Volumes.SelinuxLabel; selinuxLabel != "" {
+	if selinuxLabel := d.config.Volumes.SelinuxLabel; selinuxLabel != "" && !driverConfig.Privileged {
 		// Apply SELinux Label to each volume
 		for i := range binds {
 			binds[i].Options = append(binds[i].Options, selinuxLabel)


### PR DESCRIPTION
This will fix https://github.com/hashicorp/nomad-driver-podman/issues/184 by not applying SELinux contexts to privileged containers (CSI plugins run as privileged containers) and it will also allow for CSI plugins to correctly label SELinux contexts when mounting storage into a container when SELinux is set to enforcing.

This should close https://github.com/hashicorp/nomad-driver-podman/pull/66 as this PR would prevent SELinux contexts from being applied to CSI mounts and they would be unusable on hosts that have SELinux set to enforcing.

I have tested this with the https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver and I am able to read and write to volume mounts from this CSI plugin as expected:

```
# ls -lahZ /opt/nomad/data/client/csi/node/gcp-pd-csi/per-alloc/ec76605e-24c6-8fe4-1a84-a6d8e6a9a6ff/nginx-selinux-test/rw-file-system-single-node-writer/                          
total 20K
drwxr-xr-x. 3 root root system_u:object_r:container_file_t:s0 4.0K Oct 20 19:04 .
drwx------. 3 root root system_u:object_r:var_t:s0              47 Oct 20 19:24 ..
-rw-r--r--. 1 root root system_u:object_r:container_file_t:s0    0 Oct 20 19:04 bye.txt
-rw-r--r--. 1 root root system_u:object_r:container_file_t:s0    0 Oct 20 14:11 hello.txt
drwx------. 2 root root system_u:object_r:container_file_t:s0  16K Oct 20 11:31 lost+found
```