### PR TITLE
Entrypoint and volumes improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Ensure that Nomad can find the plugin, see [plugin_dir](https://www.nomadproject
 * volumes stanza:
 
   * enabled - Defaults to true. Allows tasks to bind host paths (volumes) inside their container.
-  * selinuxlabel - Allows the operator to set a SELinux label to the allocation and task local bind-mounts to containers. If used with _volumes.enabled_ set to false, the labels will still be applied to the standard binds in the container.
+  * selinuxlabel - Applies SELinux label to the standard binds in the container. To apply it also for additional defined volumes, `z` options needs to be applied in config->volumes section.
 
 ```hcl
 plugin "nomad-driver-podman" {
@@ -238,7 +238,8 @@ config {
 ```hcl
 config {
   volumes = [
-    "/some/host/data:/container/data:ro,noexec"
+    "/some/host/data:/container/data:ro,noexec",
+    "/additional/host/selinux_data:/container/selinux_data:z"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -198,11 +198,14 @@ config {
 }
 ```
 
-* **entrypoint** - (Optional) The entrypoint for the container. Defaults to the entrypoint set in the image.
+* **entrypoint** - (Optional) A string list overriding the image's entrypoint. Defaults to the entrypoint set in the image.
 
 ```hcl
 config {
-  entrypoint = "/entrypoint.sh"
+  entrypoint = [
+    "/bin/bash",
+    "-c"
+  ]
 }
 ```
 

--- a/config.go
+++ b/config.go
@@ -56,7 +56,7 @@ var (
 		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
 		"cpu_cfs_period": hclspec.NewAttr("cpu_cfs_period", "number", false),
 		"devices":        hclspec.NewAttr("devices", "list(string)", false),
-		"entrypoint":     hclspec.NewAttr("entrypoint", "string", false),
+		"entrypoint":     hclspec.NewAttr("entrypoint", "list(string)", false),
 		"working_dir":    hclspec.NewAttr("working_dir", "string", false),
 		"hostname":       hclspec.NewAttr("hostname", "string", false),
 		"image":          hclspec.NewAttr("image", "string", true),
@@ -135,7 +135,7 @@ type TaskConfig struct {
 	SelinuxOpts       []string           `codec:"selinux_opts"`
 	Command           string             `codec:"command"`
 	Devices           []string           `codec:"devices"`
-	Entrypoint        string             `codec:"entrypoint"`
+	Entrypoint        []string           `codec:"entrypoint"`
 	WorkingDir        string             `codec:"working_dir"`
 	Hostname          string             `codec:"hostname"`
 	Image             string             `codec:"image"`

--- a/driver.go
+++ b/driver.go
@@ -391,9 +391,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	}
 	allArgs = append(allArgs, driverConfig.Args...)
 
-	if driverConfig.Entrypoint != "" {
-		createOpts.ContainerBasicConfig.Entrypoint = append(createOpts.ContainerBasicConfig.Entrypoint, driverConfig.Entrypoint)
-	}
+	createOpts.ContainerBasicConfig.Entrypoint = driverConfig.Entrypoint
 
 	containerName := BuildContainerName(cfg)
 


### PR DESCRIPTION
changes:
1.  SELinux label is not added by default to all volumes/mounts when we specify usage of SELinux label in main Nomad config for Podman driver. This setting goes only to standard Nomad mounts. For volumes defined in job definition, we need to provide `z` label for each volume, where we want to use it.  With previous approach I was not able to mount share, that didn't require providing `z` label at all.  I had this issue on RHEL7/8 with enabled selinux and for NFS mounts. NFS mounts were not working (permission denied) when mounted with `z` label.
2.  Entrypoint works exactly the same as for Docker driver. I changed it mainly because with current approach I was not able to disable entrypoint provided in the image and use only CMD.