### PR TITLE
Volumes are not forced to use SELinux label

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Ensure that Nomad can find the plugin, see [plugin_dir](https://www.nomadproject
 * volumes stanza:
 
   * enabled - Defaults to true. Allows tasks to bind host paths (volumes) inside their container.
-  * selinuxlabel - Allows the operator to set a SELinux label to the allocation and task local bind-mounts to containers. If used with _volumes.enabled_ set to false, the labels will still be applied to the standard binds in the container.
+  * selinuxlabel - Applies SELinux label to the standard binds in the container. To apply it also for additional defined volumes, `z` options needs to be applied in config->volumes section.
 
 ```hcl
 plugin "nomad-driver-podman" {
@@ -238,7 +238,8 @@ config {
 ```hcl
 config {
   volumes = [
-    "/some/host/data:/container/data:ro,noexec"
+    "/some/host/data:/container/data:ro,noexec",
+    "/additional/host/selinux_data:/container/selinux_data:z"
   ]
 }
 ```


### PR DESCRIPTION
SELinux label is not added by default to all volumes/mounts when we specify usage of SELinux label in main Nomad config for Podman driver. This setting goes only to standard Nomad mounts. For volumes defined in job definition, we need to provide z label for each volume, where we want to use it. With previous approach I was not able to mount share, that didn't require providing z label at all. I had this issue on RHEL7/8 with enabled selinux and for NFS mounts. NFS mounts were not working (permission denied) when mounted with z label.