### PR TITLE
entrypoint supports additional arguments

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -392,7 +392,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	allArgs = append(allArgs, driverConfig.Args...)
 
 	if driverConfig.Entrypoint != "" {
-		createOpts.ContainerBasicConfig.Entrypoint = append(createOpts.ContainerBasicConfig.Entrypoint, driverConfig.Entrypoint)
+		createOpts.ContainerBasicConfig.Entrypoint = append(createOpts.ContainerBasicConfig.Entrypoint, strings.Fields(driverConfig.Entrypoint)...)
 	}
 
 	containerName := BuildContainerName(cfg)


### PR DESCRIPTION
Alternative solution to: https://github.com/hashicorp/nomad-driver-podman/pull/209

In this change, we pass entrypoint as list, when it is defined with whitespaces, eg. "/bin/bash -c" will be passed as ["/bin/bash","-c"] to podman api.  With this change, we can overwrite existing Entrypoint and Command with some new Command and neutralize image defined Entrypoint.