### PR TITLE
Allow for an `extra_labels` stanza similar to the Docker driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+* config: Add `extra_labels` option [[GH-215](https://github.com/hashicorp/nomad-driver-podman/pull/215)]
 * config: Allow setting `pids_limit` option. [[GH-203](https://github.com/hashicorp/nomad-driver-podman/pull/203)]
 * runtime: Set mount propagation from TaskConfig [[GH-204](https://github.com/hashicorp/nomad-driver-podman/pull/204)]
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ plugin "nomad-driver-podman" {
 }
 ```
 
-* recover_stopped (bool) Defaults to true. Allows the driver to start and resuse a previously stopped container after
+* recover_stopped (bool) Defaults to true. Allows the driver to start and reuse a previously stopped container after
   a Nomad client restart.
   Consider a simple single node system and a complete reboot. All previously managed containers
   will be reused instead of disposed and recreated.
@@ -168,8 +168,28 @@ plugin "nomad-driver-podman" {
 }
 ```
 
-* client_http_timeout (string) Defaults to `60s` default timeout used by http.Client requests
+* extra_labels ([]string) Defaults to `[]`. Setting this will automatically append Nomad-related labels to Podman tasks. Possible values are:
+
 ```
+job_name
+job_id
+task_group_name
+task_name
+namespace
+node_name
+node_id
+```
+
+```hcl
+plugin "nomad-driver-podman" {
+  config {
+    extra_labels = ["job_name", "job_id", "task_group_name", "task_name", "namespace", "node_name", "node_id"]
+  }
+}
+```
+
+* client_http_timeout (string) Defaults to `60s` default timeout used by http.Client requests
+```hcl
 plugin "nomad-driver-podman" {
   config {
     client_http_timeout = "60s"
@@ -505,7 +525,7 @@ Be aware that ports must be defined in the parent network namespace, here *serve
 
 See `examples/jobs/nats_pod.nomad`
 
-A slightly different setup is demonstrated in this job. It reassembles more closesly the idea of a *pod* by starting a
+A slightly different setup is demonstrated in this job. It reassembles more closely the idea of a *pod* by starting a
 pause task, named *pod* via a prestart/sidecar [hook](https://www.nomadproject.io/docs/job-specification/lifecycle).
 
 Next, the main workload, *server* is started and joins the network namespace by using the `network_mode = "task:pod"` stanza.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ plugin "nomad-driver-podman" {
 }
 ```
 
-* extra_labels ([]string) Defaults to `[]`. Setting this will automatically append Nomad-related labels to Podman tasks. Possible values are:
+* extra_labels ([]string) Defaults to `[]`. Setting this will automatically append Nomad-related labels to Podman tasks. Supports glob matching such as `task*`. Possible values are:
 
 ```
 job_name

--- a/config.go
+++ b/config.go
@@ -32,6 +32,8 @@ var (
 			hclspec.NewAttr("recover_stopped", "bool", false),
 			hclspec.NewLiteral("true"),
 		),
+		// optional extra_labels to append to all tasks for observability. Globs supported
+		"extra_labels": hclspec.NewAttr("extra_labels", "list(string)", false),
 		// the path to the podman api socket
 		"socket_path": hclspec.NewAttr("socket_path", "string", false),
 		// disable_log_collection indicates whether nomad should collect logs of podman
@@ -120,6 +122,7 @@ type PluginConfig struct {
 	DisableLogCollection bool         `codec:"disable_log_collection"`
 	SocketPath           string       `codec:"socket_path"`
 	ClientHttpTimeout    string       `codec:"client_http_timeout"`
+	ExtraLabels          []string     `codec:"extra_labels"`
 }
 
 // TaskConfig is the driver configuration of a task within a job

--- a/driver.go
+++ b/driver.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/ryanuber/go-glob"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -46,6 +47,15 @@ const (
 
 	LOG_DRIVER_NOMAD    = "nomad"
 	LOG_DRIVER_JOURNALD = "journald"
+
+	labelAllocID       = "com.hashicorp.nomad.alloc_id"
+	labelJobName       = "com.hashicorp.nomad.job_name"
+	labelJobID         = "com.hashicorp.nomad.job_id"
+	labelTaskGroupName = "com.hashicorp.nomad.task_group_name"
+	labelTaskName      = "com.hashicorp.nomad.task_name"
+	labelNamespace     = "com.hashicorp.nomad.namespace"
+	labelNodeName      = "com.hashicorp.nomad.node_name"
+	labelNodeID        = "com.hashicorp.nomad.node_id"
 )
 
 var (
@@ -400,6 +410,48 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	// ensure to include port_map into tasks environment map
 	cfg.Env = taskenv.SetPortMapEnvs(cfg.Env, driverConfig.PortMap)
 
+	if len(driverConfig.Labels) > 0 {
+		createOpts.ContainerBasicConfig.Labels = driverConfig.Labels
+	}
+
+	labels := make(map[string]string, len(driverConfig.Labels)+1)
+	for k, v := range driverConfig.Labels {
+		labels[k] = v
+	}
+
+	if len(d.config.ExtraLabels) > 0 {
+		// main mandatory label
+		labels[labelAllocID] = cfg.AllocID
+	}
+
+	//optional labels, as configured in plugin configuration
+	for _, configurationExtraLabel := range d.config.ExtraLabels {
+		if glob.Glob(configurationExtraLabel, "job_name") {
+			labels[labelJobName] = cfg.JobName
+		}
+		if glob.Glob(configurationExtraLabel, "job_id") {
+			labels[labelJobID] = cfg.JobID
+		}
+		if glob.Glob(configurationExtraLabel, "task_group_name") {
+			labels[labelTaskGroupName] = cfg.TaskGroupName
+		}
+		if glob.Glob(configurationExtraLabel, "task_name") {
+			labels[labelTaskName] = cfg.Name
+		}
+		if glob.Glob(configurationExtraLabel, "namespace") {
+			labels[labelNamespace] = cfg.Namespace
+		}
+		if glob.Glob(configurationExtraLabel, "node_name") {
+			labels[labelNodeName] = cfg.NodeName
+		}
+		if glob.Glob(configurationExtraLabel, "node_id") {
+			labels[labelNodeID] = cfg.NodeID
+		}
+	}
+
+	driverConfig.Labels = labels
+	d.logger.Debug("applied labels on the container", "labels", driverConfig.Labels)
+
 	// Basic config options
 	createOpts.ContainerBasicConfig.Name = containerName
 	createOpts.ContainerBasicConfig.Command = allArgs
@@ -411,7 +463,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 
 	// Logging
 	if driverConfig.Logging.Driver == "" || driverConfig.Logging.Driver == LOG_DRIVER_NOMAD {
-		// Only modify container loggin path if LogCollection is not disabled
+		// Only modify container logging path if LogCollection is not disabled
 		if !d.config.DisableLogCollection {
 			createOpts.LogConfiguration.Driver = "k8s-file"
 
@@ -501,7 +553,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		for _, strdns := range cfg.DNS.Servers {
 			ipdns := net.ParseIP(strdns)
 			if ipdns == nil {
-				return nil, nil, fmt.Errorf("Invald dns server address")
+				return nil, nil, fmt.Errorf("Invalid dns server address")
 			}
 			createOpts.ContainerNetworkConfig.DNSServers = append(createOpts.ContainerNetworkConfig.DNSServers, ipdns)
 		}
@@ -759,15 +811,15 @@ func sliceMergeUlimit(ulimitsRaw map[string]string) ([]spec.POSIXRlimit, error) 
 			ulimitRaw = ulimitRaw + ":" + ulimitRaw
 		}
 
-		splitted := strings.SplitN(ulimitRaw, ":", 2)
-		if len(splitted) < 2 {
+		split := strings.SplitN(ulimitRaw, ":", 2)
+		if len(split) < 2 {
 			return []spec.POSIXRlimit{}, fmt.Errorf("Malformed ulimit specification %v: %v", name, ulimitRaw)
 		}
-		soft, err := strconv.Atoi(splitted[0])
+		soft, err := strconv.Atoi(split[0])
 		if err != nil {
 			return []spec.POSIXRlimit{}, fmt.Errorf("Malformed soft ulimit %v: %v", name, ulimitRaw)
 		}
-		hard, err := strconv.Atoi(splitted[1])
+		hard, err := strconv.Atoi(split[1])
 		if err != nil {
 			return []spec.POSIXRlimit{}, fmt.Errorf("Malformed hard ulimit %v: %v", name, ulimitRaw)
 		}

--- a/driver_test.go
+++ b/driver_test.go
@@ -552,8 +552,6 @@ func TestPodmanDriver_ExtraLabels(t *testing.T) {
 
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
 
-	defer cleanup()
-
 	_, _, err := d.StartTask(task)
 	require.NoError(t, err)
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -89,6 +89,11 @@ func podmanDriverHarness(t *testing.T, cfg map[string]interface{}) *dtestutil.Dr
 			d.config.GC.Container = bv
 		}
 	}
+	if v, ok := cfg["extra_labels"]; ok {
+		if bv, ok := v.([]string); ok {
+			d.config.ExtraLabels = bv
+		}
+	}
 
 	harness := dtestutil.NewDriverHarness(t, d)
 
@@ -514,6 +519,66 @@ func TestPodmanDriver_logNomad(t *testing.T) {
 	stdoutLog := readStdoutLog(t, task)
 	require.Contains(t, stdoutLog, stdoutMagic, "stdoutMagic in stdout")
 	require.Contains(t, stdoutLog, stderrMagic, "stderrMagic in stdout")
+}
+
+// check if extra labels make it into logs
+func TestPodmanDriver_ExtraLabels(t *testing.T) {
+	if !tu.IsCI() {
+		t.Parallel()
+	}
+
+	taskCfg := newTaskConfig("", []string{
+		"sh",
+		"-c",
+		fmt.Sprintf("sleep 1"),
+	})
+
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "extra_labels",
+		AllocID:   uuid.Generate(),
+		Resources: createBasicResources(),
+	}
+	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+	opts := make(map[string]interface{})
+	opts["extra_labels"] = []string{"task_name"}
+
+	containerName := BuildContainerName(task)
+
+	d := podmanDriverHarness(t, opts)
+	cleanup := d.MkAllocDir(task, true)
+	defer cleanup()
+
+	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+	defer cleanup()
+
+	_, _, err := d.StartTask(task)
+	require.NoError(t, err)
+
+	defer func() {
+		_ = d.DestroyTask(task.ID, true)
+	}()
+
+	// Attempt to wait
+	waitCh, err := d.WaitTask(context.Background(), task.ID)
+	require.NoError(t, err)
+
+	inspectData, err := getPodmanDriver(t, d).podman.ContainerInspect(context.Background(), containerName)
+	require.NoError(t, err)
+
+	select {
+	case <-waitCh:
+	case <-time.After(time.Duration(tu.TestMultiplier()*4) * time.Second):
+		t.Fatalf("Container did not exit in time")
+	}
+
+	expectedLabels := map[string]string{
+		"com.hashicorp.nomad.alloc_id":  string(task.AllocID),
+		"com.hashicorp.nomad.task_name": "extra_labels",
+	}
+	require.Exactly(t, expectedLabels, inspectData.Config.Labels)
 }
 
 // check hostname task config options
@@ -1246,7 +1311,7 @@ func TestPodmanDriver_Mount(t *testing.T) {
 		"mount|grep check",
 	})
 	taskCfg.Volumes = []string{
-		// explicitely check that we can have more then one option
+		// explicitly check that we can have more then one option
 		"/tmp:/checka:ro,shared",
 		"/tmp:/checkb:private",
 		"/tmp:/checkc",


### PR DESCRIPTION
Log collection in observability stacks (such as [via Vector](https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/vector)) when using the `podman` driver isn't as literate as Docker. 

Add the option to add extra labels so promtail/vector/filebeat/whatever can get a view of what Nomad-related things running Podman containers may be doing.