### PR TITLE
driver: fix image_pull_timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,15 @@ jobs:
         sudo podman save --format docker-archive --output $ARCHIVE_DIR/docker-archive alpine:latest
         sudo podman save --format oci-archive --output $ARCHIVE_DIR/oci-archive alpine:latest
         sudo podman image rm alpine:latest
+    - name: Setup registries for testing
+      run: |
+        sudo bash -c 'cat <<EOF > /etc/containers/registries.conf
+        unqualified-search-registries = ["docker.io", "quay.io"]
+
+        [[registry]]
+        location = "localhost:5000"
+        insecure = true
+        EOF'
     - name: Run Tests
       run: sudo -E GOPATH=$PWD/build CI=1 env PATH="$PATH" /home/runner/go/bin/gotestsum --junitfile build/test/result.xml -- -timeout=15m . ./api
     - name: Archive test result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ IMPROVEMENTS:
 * config: Allow setting `pids_limit` option. [[GH-203](https://github.com/hashicorp/nomad-driver-podman/pull/203)]
 * runtime: Set mount propagation from TaskConfig [[GH-204](https://github.com/hashicorp/nomad-driver-podman/pull/204)]
 
+BUG FIXES:
+
+* driver: Fixed a bug that caused `image_pull_timeout` to the capped by the value of `client_http_timeout` [[GH-218](https://github.com/hashicorp/nomad-driver-podman/pull/218)]
 
 ## 0.4.1 (November 15, 2022)
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -7,6 +7,11 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,6 +77,15 @@ func podmanDriverHarness(t *testing.T, cfg map[string]interface{}) *dtestutil.Dr
 
 	baseConfig := base.Config{}
 	pluginConfig := PluginConfig{}
+
+	// Set ClientHttpTimeout before calling SetConfig() because it affects the
+	// HTTP client that is created.
+	if v, ok := cfg["ClientHttpTimeout"]; ok {
+		if sv, ok := v.(string); ok {
+			pluginConfig.ClientHttpTimeout = sv
+		}
+	}
+
 	if err := base.MsgPackEncode(&baseConfig.PluginConfig, &pluginConfig); err != nil {
 		t.Error("Unable to encode plugin config", err)
 	}
@@ -1912,6 +1926,91 @@ func startDestroyInspectImage(t *testing.T, image string, taskName string) {
 	imageID, err := getPodmanDriver(t, d).createImage(image, &AuthConfig{}, false, 5*time.Minute, task)
 	require.NoError(t, err)
 	require.Equal(t, imageID, inspectData.Image)
+}
+
+// TestPodmanDriver_Pull_Timeout verifies that the task image_pull_timeout
+// configuration is respected and that it can be set to higher value than the
+// driver's client_http_timeout.
+//
+// This test starts a proxy on port 5000 and requires the machine running the
+// test to allow an insecure registry at localhost:5000. To run this test add
+// the following to /etc/containers/registries.conf:
+//
+// [[registry]]
+// location = "localhost:5000"
+// insecure = true
+func TestPodmanDriver_Pull_Timeout(t *testing.T) {
+	// Check if the machine running the test is properly configured to run this
+	// test.
+	expectedRegistry := `[[registry]]
+location = "localhost:5000"
+insecure = true`
+
+	content, err := os.ReadFile("/etc/containers/registries.conf")
+	require.NoError(t, err)
+	if !strings.Contains(string(content), expectedRegistry) {
+		t.Skip("Skipping test because /etc/containers/registries.conf doesn't have insecure registry config for localhost:5000")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a listener on port 5000.
+	l, err := net.Listen("tcp", "127.0.0.1:5000")
+	require.NoError(t, err)
+
+	// Proxy requests to quay.io except when trying to pull a busybox image.
+	parsedURL, err := url.Parse("https://quay.io")
+	require.NoError(t, err)
+
+	proxy := httputil.NewSingleHostReverseProxy(parsedURL)
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if strings.Contains(resp.Request.URL.Path, "busybox") {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(5 * time.Second):
+				return fmt.Errorf("expected image pull to timeout")
+			}
+		}
+		return nil
+	}
+	// Create a new HTTP test server but don't start it so we can use our
+	// own listener on port 5000.
+	ts := httptest.NewUnstartedServer(proxy)
+	ts.Listener.Close()
+	ts.Listener = l
+	ts.Start()
+	defer ts.Close()
+
+	// Create the test harness and a sample task.
+	d := podmanDriverHarness(t, map[string]interface{}{
+		"ClientHttpTimeout": "1s",
+	})
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "test",
+		AllocID:   uuid.Generate(),
+		Resources: createBasicResources(),
+	}
+
+	// Time how long it takes to pull the image.
+	now := time.Now()
+
+	resultCh := make(chan error)
+	go func() {
+		// Pull image using our proxy.
+		image := "localhost:5000/quay/busybox:latest"
+		_, err = getPodmanDriver(t, d).createImage(image, &AuthConfig{}, true, 3*time.Second, task)
+		resultCh <- err
+	}()
+
+	err = <-resultCh
+	cancel()
+
+	// Verify that the timeout happened after client_http_timeout.
+	require.Greater(t, time.Now().Sub(now), 2*time.Second)
+	require.ErrorContains(t, err, "context deadline exceeded")
 }
 
 func Test_createImage(t *testing.T) {


### PR DESCRIPTION
Previously the value for `image_pull_timeout` was being capped by `client_http_timeout` because the image pull request used the same HTTP client as other requests.

Increasing `client_http_timeout` in order to be able to set a higher `image_pull_timeout` is not a good option since it requires updating all client's configuration. It also affects all other HTTP requests, which may not be desirable.

The change creates a separate client for slow operations that don't have a timeout configured. Operation timeout is controlled using a ContextWithTimeout().

Closes #207