### PR TITLE
Fix `image_pull_timeout` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ config {
 }
 ```
 
-* **image_pull_timeout** - (Optional) time duration for your pull timeout (default to 5m), cannot be longer than the client_http_timeout
+* **image_pull_timeout** - (Optional) time duration for your pull timeout (default to 5m).
 ```
 config {
   image_pull_timeout = "5m"


### PR DESCRIPTION
#218 made it so  `image_pull_timeout` CAN be longer than `client_http_timeout`.  This PR is simply a fix of the overlooked README which affects the docs site.