### PR TITLE
tests: detect CI without using nomad import

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -81,7 +81,6 @@ test: ## Run unit tests
 	go test -v -race ./...
 
 .PHONY: test-ci
-test-ci: CI=1
 test-ci: ## Run unit tests in CI
 	@echo "==> Running unit tests in CI ..."
 	@$(BIN)/gotestsum --format=testname --rerun-fails=0 --packages=". ./api" -- \

--- a/ci/parallel.go
+++ b/ci/parallel.go
@@ -1,0 +1,12 @@
+package ci
+
+import (
+	"os"
+	"testing"
+)
+
+func Parallel(t *testing.T) {
+	if os.Getenv("CI") == "" {
+		t.Parallel()
+	}
+}

--- a/ci/parallel.go
+++ b/ci/parallel.go
@@ -1,12 +1,13 @@
 package ci
 
 import (
-	"os"
 	"testing"
 )
 
+// Parallel provides a hook for tests that can potentially
+// be run in parallel.
 func Parallel(t *testing.T) {
-	if os.Getenv("CI") == "" {
-		t.Parallel()
-	}
+	// always run in parallel
+	// (remove when debugging, etc.)
+	t.Parallel()
 }

--- a/ci/special.go
+++ b/ci/special.go
@@ -1,0 +1,9 @@
+package ci
+
+import (
+	"os"
+)
+
+func TestSELinux() bool {
+	return os.Getenv("CI_SELINUX") == "1"
+}

--- a/config_test.go
+++ b/config_test.go
@@ -6,15 +6,16 @@ package main
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad-driver-podman/ci"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/shoenig/test/must"
 )
 
 func TestConfig_Ports(t *testing.T) {
+	ci.Parallel(t)
+
 	parser := hclutils.NewConfigParser(taskConfigSpec)
-
 	expectedPorts := []string{"redis"}
-
 	validHCL := `
   config {
 	image = "docker://redis"
@@ -28,11 +29,11 @@ func TestConfig_Ports(t *testing.T) {
 }
 
 func TestConfig_Logging(t *testing.T) {
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	ci.Parallel(t)
 
+	parser := hclutils.NewConfigParser(taskConfigSpec)
 	expectedDriver := "journald"
 	expectedTag := "redis"
-
 	validHCL := `
   config {
 	  image = "docker://redis"
@@ -54,8 +55,9 @@ func TestConfig_Logging(t *testing.T) {
 }
 
 func TestConfig_Labels(t *testing.T) {
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	ci.Parallel(t)
 
+	parser := hclutils.NewConfigParser(taskConfigSpec)
 	validHCL := `
   config {
 	  image = "docker://redis"
@@ -71,8 +73,9 @@ func TestConfig_Labels(t *testing.T) {
 }
 
 func TestConfig_ForcePull(t *testing.T) {
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	ci.Parallel(t)
 
+	parser := hclutils.NewConfigParser(taskConfigSpec)
 	validHCL := `
   config {
 		image = "docker://redis"
@@ -86,8 +89,9 @@ func TestConfig_ForcePull(t *testing.T) {
 }
 
 func TestConfig_CPUHardLimit(t *testing.T) {
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	ci.Parallel(t)
 
+	parser := hclutils.NewConfigParser(taskConfigSpec)
 	validHCL := `
   config {
 		image = "docker://redis"
@@ -103,8 +107,9 @@ func TestConfig_CPUHardLimit(t *testing.T) {
 }
 
 func TestConfig_ImagePullTimeout(t *testing.T) {
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	ci.Parallel(t)
 
+	parser := hclutils.NewConfigParser(taskConfigSpec)
 	validHCL := `
   config {
 		image = "docker://redis"

--- a/driver_test.go
+++ b/driver_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	dtestutil "github.com/hashicorp/nomad/plugins/drivers/testutils"
-	tu "github.com/hashicorp/nomad/testutil"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/shoenig/test/must"
 )
@@ -183,7 +182,7 @@ func TestPodmanDriver_Start_Wait(t *testing.T) {
 	select {
 	case <-waitCh:
 		t.Fatalf("wait channel should not have received an exit result")
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 	}
 }
 
@@ -218,7 +217,7 @@ func TestPodmanDriver_Start_WaitFinish(t *testing.T) {
 	select {
 	case res := <-waitCh:
 		must.True(t, res.Successful())
-	case <-time.After(time.Duration(tu.TestMultiplier()*5) * time.Second):
+	case <-time.After(20 * time.Second):
 		must.Unreachable(t, must.Sprint("timeout"))
 	}
 }
@@ -308,7 +307,7 @@ func TestPodmanDriver_Start_Wait_AllocDir(t *testing.T) {
 	select {
 	case res := <-waitCh:
 		must.True(t, res.Successful())
-	case <-time.After(time.Duration(tu.TestMultiplier()*5) * time.Second):
+	case <-time.After(20 * time.Second):
 		must.Unreachable(t, must.Sprint("timeout"))
 	}
 
@@ -357,7 +356,7 @@ func TestPodmanDriver_GC_Container_on(t *testing.T) {
 	select {
 	case <-waitCh:
 		t.Fatalf("wait channel should not have received an exit result")
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 	}
 
 	_ = d.DestroyTask(task.ID, true)
@@ -403,7 +402,7 @@ func TestPodmanDriver_GC_Container_off(t *testing.T) {
 	select {
 	case <-waitCh:
 		t.Fatalf("wait channel should not have received an exit result")
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 	}
 
 	_ = d.DestroyTask(task.ID, true)
@@ -455,7 +454,7 @@ func TestPodmanDriver_logJournald(t *testing.T) {
 
 	select {
 	case <-waitCh:
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -506,7 +505,7 @@ func TestPodmanDriver_logNomad(t *testing.T) {
 
 	select {
 	case <-waitCh:
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -562,7 +561,7 @@ func TestPodmanDriver_ExtraLabels(t *testing.T) {
 
 	select {
 	case <-waitCh:
-	case <-time.After(time.Duration(tu.TestMultiplier()*4) * time.Second):
+	case <-time.After(20 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -612,7 +611,7 @@ func TestPodmanDriver_Hostname(t *testing.T) {
 
 	select {
 	case <-waitCh:
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -963,7 +962,7 @@ func TestPodmanDriver_Init(t *testing.T) {
 
 	select {
 	case <-waitCh:
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -1030,7 +1029,7 @@ func TestPodmanDriver_OOM(t *testing.T) {
 		must.False(t, res.Successful(), must.Sprint("Should have failed because of oom but was successful"))
 		must.True(t, res.OOMKilled, must.Sprint("OOM Flag not set"))
 		must.ErrorContains(t, res.Err, "OOM killer")
-	case <-time.After(time.Duration(tu.TestMultiplier()*3) * time.Second):
+	case <-time.After(20 * time.Second):
 		must.Unreachable(t, must.Sprint("Container did not exit in time"))
 	}
 }
@@ -1078,7 +1077,7 @@ func TestPodmanDriver_User(t *testing.T) {
 	case res := <-waitCh:
 		// should have a exitcode=0 result
 		must.True(t, res.Successful())
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		must.Unreachable(t, must.Sprint("Container did not exit in time"))
 	}
 
@@ -1126,7 +1125,7 @@ func TestPodmanDriver_Device(t *testing.T) {
 	case res := <-waitCh:
 		// should have a exitcode=0 result
 		must.True(t, res.Successful())
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -1177,7 +1176,7 @@ func TestPodmanDriver_Swap(t *testing.T) {
 	select {
 	case <-waitCh:
 		t.Fatalf("wait channel should not have received an exit result")
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 	}
 	// inspect container to learn about the actual podman limits
 	inspectData, err := getPodmanDriver(t, d).podman.ContainerInspect(context.Background(), containerName)
@@ -1235,7 +1234,7 @@ func TestPodmanDriver_Tmpfs(t *testing.T) {
 
 	select {
 	case <-waitCh:
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -1299,7 +1298,7 @@ func TestPodmanDriver_Mount(t *testing.T) {
 
 	select {
 	case <-waitCh:
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -1597,7 +1596,7 @@ func TestPodmanDriver_DNS(t *testing.T) {
 	case res := <-waitCh:
 		// should have a exitcode=0 result
 		must.True(t, res.Successful())
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -1668,7 +1667,7 @@ func TestPodmanDriver_NetworkModes(t *testing.T) {
 				_ = d.DestroyTask(task.ID, true)
 			}()
 
-			must.NoError(t, d.WaitUntilStarted(task.ID, time.Duration(tu.TestMultiplier()*3)*time.Second))
+			must.NoError(t, d.WaitUntilStarted(task.ID, 20*time.Second))
 
 			inspectData, err := getPodmanDriver(t, d).podman.ContainerInspect(context.Background(), containerName)
 			must.NoError(t, err)
@@ -1747,7 +1746,7 @@ func TestPodmanDriver_NetworkMode_Container(t *testing.T) {
 	case res := <-waitCh:
 		// should have a exitcode=0 result
 		must.True(t, res.Successful())
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Sidecar did not exit in time")
 	}
 
@@ -1823,7 +1822,7 @@ func TestPodmanDriver_NetworkMode_Task(t *testing.T) {
 	case res := <-waitCh:
 		// should have a exitcode=0 result
 		must.True(t, res.Successful())
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Sidecar did not exit in time")
 	}
 
@@ -1870,7 +1869,7 @@ func TestPodmanDriver_SignalTask(t *testing.T) {
 	select {
 	case res := <-waitCh:
 		must.Eq(t, 130, res.ExitCode)
-	case <-time.After(time.Duration(tu.TestMultiplier()*5) * time.Second):
+	case <-time.After(60 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 }
@@ -1910,7 +1909,7 @@ func TestPodmanDriver_Sysctl(t *testing.T) {
 
 	select {
 	case <-waitCh:
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(20 * time.Second):
 		t.Fatalf("Container did not exit in time")
 	}
 
@@ -2392,7 +2391,7 @@ func startDestroyInspect(t *testing.T, taskCfg TaskConfig, taskName string) api.
 	select {
 	case <-waitCh:
 		t.Fatalf("wait channel should not have received an exit result")
-	case <-time.After(time.Duration(tu.TestMultiplier()*2) * time.Second):
+	case <-time.After(20 * time.Second):
 	}
 	inspectData, err := getPodmanDriver(t, d).podman.ContainerInspect(context.Background(), containerName)
 	must.NoError(t, err)

--- a/driver_test.go
+++ b/driver_test.go
@@ -126,9 +126,7 @@ func TestPodmanDriver_PingPodman(t *testing.T) {
 }
 
 func TestPodmanDriver_Start_NoImage(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := TaskConfig{
 		Command: "echo",
@@ -155,9 +153,7 @@ func TestPodmanDriver_Start_NoImage(t *testing.T) {
 
 // start a long running container
 func TestPodmanDriver_Start_Wait(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	task := &drivers.TaskConfig{
@@ -192,9 +188,7 @@ func TestPodmanDriver_Start_Wait(t *testing.T) {
 
 // test a short-living container
 func TestPodmanDriver_Start_WaitFinish(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{"echo", "hello"})
 	task := &drivers.TaskConfig{
@@ -233,9 +227,7 @@ func TestPodmanDriver_Start_WaitFinish(t *testing.T) {
 //
 // See https://github.com/hashicorp/nomad/issues/3419
 func TestPodmanDriver_Start_StoppedContainer(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{"sleep", "5"})
 	task := &drivers.TaskConfig{
@@ -278,9 +270,7 @@ func TestPodmanDriver_Start_StoppedContainer(t *testing.T) {
 }
 
 func TestPodmanDriver_Start_Wait_AllocDir(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	exp := []byte{'w', 'i', 'n'}
 	file := "output.txt"
@@ -335,9 +325,7 @@ func TestPodmanDriver_Start_Wait_AllocDir(t *testing.T) {
 
 // check if container is destroyed if gc.container=true
 func TestPodmanDriver_GC_Container_on(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	task := &drivers.TaskConfig{
@@ -380,9 +368,7 @@ func TestPodmanDriver_GC_Container_on(t *testing.T) {
 
 // check if container is destroyed if gc.container=false
 func TestPodmanDriver_GC_Container_off(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	task := &drivers.TaskConfig{
@@ -432,9 +418,7 @@ func TestPodmanDriver_GC_Container_off(t *testing.T) {
 
 // Check log_opt=journald logger
 func TestPodmanDriver_logJournald(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	stdoutMagic := uuid.Generate()
 	stderrMagic := uuid.Generate()
@@ -485,9 +469,7 @@ func TestPodmanDriver_logJournald(t *testing.T) {
 
 // Check log_opt=nomad logger
 func TestPodmanDriver_logNomad(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	stdoutMagic := uuid.Generate()
 	stderrMagic := uuid.Generate()
@@ -536,9 +518,7 @@ func TestPodmanDriver_logNomad(t *testing.T) {
 
 // check if extra labels make it into logs
 func TestPodmanDriver_ExtraLabels(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{
 		"sh",
@@ -595,9 +575,7 @@ func TestPodmanDriver_ExtraLabels(t *testing.T) {
 
 // check hostname task config options
 func TestPodmanDriver_Hostname(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{
 		// print hostname to stdout
@@ -645,9 +623,8 @@ func TestPodmanDriver_Hostname(t *testing.T) {
 
 // check port_map feature
 func TestPodmanDriver_PortMap(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
+
 	ports := ci.PortAllocator.Grab(2)
 
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
@@ -717,9 +694,7 @@ func TestPodmanDriver_PortMap(t *testing.T) {
 }
 
 func TestPodmanDriver_Ports(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	ports := ci.PortAllocator.Grab(2)
 
@@ -805,9 +780,7 @@ func TestPodmanDriver_Ports(t *testing.T) {
 }
 
 func TestPodmanDriver_Ports_MissingFromGroup(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	ports := ci.PortAllocator.Grab(1)
 
@@ -855,9 +828,7 @@ func TestPodmanDriver_Ports_MissingFromGroup(t *testing.T) {
 }
 
 func TestPodmanDriver_Ports_MissingDriverConfig(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	ports := ci.PortAllocator.Grab(1)
 
@@ -893,9 +864,7 @@ func TestPodmanDriver_Ports_MissingDriverConfig(t *testing.T) {
 }
 
 func TestPodmanDriver_Ports_WithPortMap(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	ports := ci.PortAllocator.Grab(1)
 
@@ -950,9 +919,7 @@ func TestPodmanDriver_Ports_WithPortMap(t *testing.T) {
 
 // check --init with default path
 func TestPodmanDriver_Init(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	// only test --init if catatonit is installed
 	initPath, err := exec.LookPath("catatonit")
@@ -1007,12 +974,9 @@ func TestPodmanDriver_Init(t *testing.T) {
 
 // test oom flag propagation
 func TestPodmanDriver_OOM(t *testing.T) {
+	ci.Parallel(t)
 
 	t.Skip("Skipping oom test because of podman cgroup v2 bugs")
-
-	if !tu.IsCI() {
-		t.Parallel()
-	}
 
 	taskCfg := newTaskConfig("", []string{
 		// Incrementally creates a bigger and bigger variable.
@@ -1075,9 +1039,7 @@ func TestPodmanDriver_User(t *testing.T) {
 	// if os.Getuid() != 0 {
 	// 	t.Skip("Skipping User test ")
 	// }
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{
 		// print our username to stdout
@@ -1126,9 +1088,7 @@ func TestPodmanDriver_User(t *testing.T) {
 }
 
 func TestPodmanDriver_Device(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{
 		// print our username to stdout
@@ -1177,9 +1137,7 @@ func TestPodmanDriver_Device(t *testing.T) {
 
 // test memory/swap options
 func TestPodmanDriver_Swap(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	task := &drivers.TaskConfig{
@@ -1236,9 +1194,7 @@ func TestPodmanDriver_Swap(t *testing.T) {
 
 // check tmpfs mounts
 func TestPodmanDriver_Tmpfs(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{
 		// print our username to stdout
@@ -1300,9 +1256,7 @@ func TestPodmanDriver_Tmpfs(t *testing.T) {
 
 // check mount options
 func TestPodmanDriver_Mount(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{
 		// print our username to stdout
@@ -1409,7 +1363,7 @@ func TestPodmanDriver_DefaultProcessLabel(t *testing.T) {
 
 	// TODO: skip SELinux check in CI since it's not supported yet.
 	// https://github.com/hashicorp/nomad-driver-podman/pull/139#issuecomment-1192929834
-	if !tu.IsCI() {
+	if os.Getenv("CI") == "" {
 		// a default container gets "disable" process label
 		must.StrContains(t, inspectData.ProcessLabel, "label=disable")
 	}
@@ -1440,7 +1394,7 @@ func TestPodmanDriver_Caps(t *testing.T) {
 
 	// TODO: skip SELinux check in CI since it's not supported yet.
 	// https://github.com/hashicorp/nomad-driver-podman/pull/139#issuecomment-1192929834
-	if !tu.IsCI() {
+	if os.Getenv("CI") != "" {
 		// we added "disable" process label, so we should see it in inspect
 		must.StrContains(t, inspectData.ProcessLabel, "label=disable")
 	}
@@ -1570,9 +1524,7 @@ func TestPodmanDriver_UsernsModeParsed(t *testing.T) {
 
 // check dns server configuration
 func TestPodmanDriver_Dns(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{
 		"sh",
@@ -1633,9 +1585,7 @@ func TestPodmanDriver_Dns(t *testing.T) {
 // TestPodmanDriver_NetworkMode asserts we can specify different network modes
 // Default podman cni subnet 10.88.0.0/16
 func TestPodmanDriver_NetworkModes(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	testCases := []struct {
 		mode     string
@@ -1705,9 +1655,8 @@ func TestPodmanDriver_NetworkModes(t *testing.T) {
 
 // let a task join NetworkNS of another container via network_mode=container:
 func TestPodmanDriver_NetworkMode_Container(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
+
 	allocId := uuid.Generate()
 
 	// we're running "nc" on localhost here
@@ -1782,9 +1731,8 @@ func TestPodmanDriver_NetworkMode_Container(t *testing.T) {
 
 // let a task joint NetorkNS of another container via network_mode=task:
 func TestPodmanDriver_NetworkMode_Task(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
+
 	allocId := uuid.Generate()
 
 	// we're running "nc" on localhost here
@@ -1859,9 +1807,7 @@ func TestPodmanDriver_NetworkMode_Task(t *testing.T) {
 
 // test kill / signal support
 func TestPodmanDriver_SignalTask(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	task := &drivers.TaskConfig{
@@ -1903,9 +1849,7 @@ func TestPodmanDriver_SignalTask(t *testing.T) {
 }
 
 func TestPodmanDriver_Sysctl(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	// set a uncommon somaxconn value and echo the effective
 	// in-container value
@@ -1950,9 +1894,7 @@ func TestPodmanDriver_Sysctl(t *testing.T) {
 
 // Make sure we can pull and start "non-latest" containers
 func TestPodmanDriver_Pull(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	type imageTestCase struct {
 		Image    string
@@ -2080,9 +2022,7 @@ insecure = true`
 }
 
 func Test_createImage(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	testCases := []struct {
 		Image     string
@@ -2099,9 +2039,7 @@ func Test_createImage(t *testing.T) {
 }
 
 func Test_createImageArchives(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	doesNotExist := func(filepath string) bool {
 		_, err := os.Stat(filepath)
@@ -2324,9 +2262,7 @@ func Test_memoryLimits(t *testing.T) {
 }
 
 func Test_parseImage(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	digest := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	testCases := []struct {
@@ -2395,9 +2331,7 @@ func getPodmanDriver(t *testing.T, harness *dtestutil.DriverHarness) *Driver {
 
 // helper to start, destroy and inspect a long running container
 func startDestroyInspect(t *testing.T, taskCfg TaskConfig, taskName string) api.InspectContainerData {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
+	ci.Parallel(t)
 
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),

--- a/driver_test.go
+++ b/driver_test.go
@@ -68,7 +68,6 @@ func createBasicResources() *drivers.Resources {
 // podmanDriverHarness wires up everything needed to launch a task with a podman driver.
 // A driver plugin interface and cleanup function is returned
 func podmanDriverHarness(t *testing.T, cfg map[string]interface{}) *dtestutil.DriverHarness {
-
 	logger := testlog.HCLogger(t)
 	if testing.Verbose() {
 		logger.SetLevel(hclog.Trace)
@@ -119,6 +118,8 @@ func podmanDriverHarness(t *testing.T, cfg map[string]interface{}) *dtestutil.Dr
 }
 
 func TestPodmanDriver_PingPodman(t *testing.T) {
+	ci.Parallel(t)
+
 	d := podmanDriverHarness(t, nil)
 	version, err := getPodmanDriver(t, d).podman.Ping(context.Background())
 	must.NoError(t, err)
@@ -1347,6 +1348,8 @@ func TestPodmanDriver_Mount(t *testing.T) {
 
 // check default capabilities
 func TestPodmanDriver_DefaultCaps(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	inspectData := startDestroyInspect(t, taskCfg, "defaultcaps")
 
@@ -1358,12 +1361,14 @@ func TestPodmanDriver_DefaultCaps(t *testing.T) {
 
 // check default process label
 func TestPodmanDriver_DefaultProcessLabel(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	inspectData := startDestroyInspect(t, taskCfg, "defaultprocesslabel")
 
 	// TODO: skip SELinux check in CI since it's not supported yet.
 	// https://github.com/hashicorp/nomad-driver-podman/pull/139#issuecomment-1192929834
-	if os.Getenv("CI") == "" {
+	if ci.TestSELinux() {
 		// a default container gets "disable" process label
 		must.StrContains(t, inspectData.ProcessLabel, "label=disable")
 	}
@@ -1371,6 +1376,8 @@ func TestPodmanDriver_DefaultProcessLabel(t *testing.T) {
 
 // check modified capabilities (CapAdd/CapDrop/SelinuxOpts)
 func TestPodmanDriver_Caps(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	// 	cap_add = [
 	//     "SYS_TIME",
@@ -1394,7 +1401,7 @@ func TestPodmanDriver_Caps(t *testing.T) {
 
 	// TODO: skip SELinux check in CI since it's not supported yet.
 	// https://github.com/hashicorp/nomad-driver-podman/pull/139#issuecomment-1192929834
-	if os.Getenv("CI") != "" {
+	if ci.TestSELinux() {
 		// we added "disable" process label, so we should see it in inspect
 		must.StrContains(t, inspectData.ProcessLabel, "label=disable")
 	}
@@ -1402,6 +1409,8 @@ func TestPodmanDriver_Caps(t *testing.T) {
 
 // check enabled tty option
 func TestPodmanDriver_Tty(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	taskCfg.Tty = true
 	inspectData := startDestroyInspect(t, taskCfg, "tty")
@@ -1410,6 +1419,8 @@ func TestPodmanDriver_Tty(t *testing.T) {
 
 // check labels option
 func TestPodmanDriver_Labels(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	taskCfg.Labels = map[string]string{"nomad": "job"}
 	inspectData := startDestroyInspect(t, taskCfg, "labels")
@@ -1419,6 +1430,8 @@ func TestPodmanDriver_Labels(t *testing.T) {
 
 // check enabled privileged option
 func TestPodmanDriver_Privileged(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	taskCfg.Privileged = true
 	inspectData := startDestroyInspect(t, taskCfg, "privileged")
@@ -1427,6 +1440,8 @@ func TestPodmanDriver_Privileged(t *testing.T) {
 
 // check apparmor default value
 func TestPodmanDriver_AppArmorDefault(t *testing.T) {
+	ci.Parallel(t)
+
 	d := podmanDriverHarness(t, nil)
 
 	// Skip test if apparmor is not available
@@ -1441,6 +1456,8 @@ func TestPodmanDriver_AppArmorDefault(t *testing.T) {
 
 // check apparmor option
 func TestPodmanDriver_AppArmorUnconfined(t *testing.T) {
+	ci.Parallel(t)
+
 	d := podmanDriverHarness(t, nil)
 
 	// Skip test if apparmor is not available
@@ -1456,6 +1473,8 @@ func TestPodmanDriver_AppArmorUnconfined(t *testing.T) {
 
 // check ulimit option
 func TestPodmanDriver_Ulimit(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	taskCfg.Ulimit = map[string]string{"nproc": "4096", "nofile": "2048:4096"}
 	inspectData := startDestroyInspect(t, taskCfg, "ulimits")
@@ -1483,6 +1502,8 @@ func TestPodmanDriver_Ulimit(t *testing.T) {
 
 // check pids_limit option
 func TestPodmanDriver_PidsLimit(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	// set a random pids limit
 	taskCfg.PidsLimit = int64(100 + rand.Intn(100))
@@ -1493,6 +1514,8 @@ func TestPodmanDriver_PidsLimit(t *testing.T) {
 
 // check enabled readonly_rootfs option
 func TestPodmanDriver_ReadOnlyFilesystem(t *testing.T) {
+	ci.Parallel(t)
+
 	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 	taskCfg.ReadOnlyRootfs = true
 	inspectData := startDestroyInspect(t, taskCfg, "readonly_rootfs")
@@ -1501,6 +1524,8 @@ func TestPodmanDriver_ReadOnlyFilesystem(t *testing.T) {
 
 // check userns mode configuration (single value)
 func TestPodmanDriver_UsernsMode(t *testing.T) {
+	ci.Parallel(t)
+
 	// TODO: run test once CI can use rootless Podman.
 	t.Skip("Test suite requires rootful Podman")
 
@@ -1513,6 +1538,8 @@ func TestPodmanDriver_UsernsMode(t *testing.T) {
 
 // check userns mode configuration (parsed value)
 func TestPodmanDriver_UsernsModeParsed(t *testing.T) {
+	ci.Parallel(t)
+
 	// TODO: run test once CI can use rootless Podman.
 	t.Skip("Test suite requires rootful Podman")
 
@@ -1523,7 +1550,7 @@ func TestPodmanDriver_UsernsModeParsed(t *testing.T) {
 }
 
 // check dns server configuration
-func TestPodmanDriver_Dns(t *testing.T) {
+func TestPodmanDriver_DNS(t *testing.T) {
 	ci.Parallel(t)
 
 	taskCfg := newTaskConfig("", []string{
@@ -1948,6 +1975,8 @@ func startDestroyInspectImage(t *testing.T, image string, taskName string) {
 // location = "localhost:5000"
 // insecure = true
 func TestPodmanDriver_Pull_Timeout(t *testing.T) {
+	ci.Parallel(t)
+
 	// Check if the machine running the test is properly configured to run this
 	// test.
 	expectedRegistry := `[[registry]]
@@ -2096,6 +2125,8 @@ func createInspectImage(t *testing.T, image, reference string) {
 }
 
 func Test_cpuLimits(t *testing.T) {
+	ci.Parallel(t)
+
 	numCores := runtime.NumCPU()
 	cases := []struct {
 		name            string
@@ -2184,6 +2215,8 @@ func Test_cpuLimits(t *testing.T) {
 }
 
 func Test_memoryLimits(t *testing.T) {
+	ci.Parallel(t)
+
 	cases := []struct {
 		name         string
 		memResources drivers.MemoryResources
@@ -2331,8 +2364,6 @@ func getPodmanDriver(t *testing.T, harness *dtestutil.DriverHarness) *Driver {
 
 // helper to start, destroy and inspect a long running container
 func startDestroyInspect(t *testing.T, taskCfg TaskConfig, taskName string) api.InspectContainerData {
-	ci.Parallel(t)
-
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      taskName,


### PR DESCRIPTION
This PR

- adds a `ci.Parallel()` helper
- calls that instead of `testutils.IsCI()` from the `nomad` package
- runs most tests in parallel by default now
- replaces some duration calculation with direct values instead of calling `testutils.TestMultiplier()`
- add an explicit check for whether SELinux tests should run (`$CI_SELINUX`)