### PR TITLE
build: do not run check step during dev build

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,7 +68,7 @@ pkg/%.zip: pkg/%/nomad-driver-podman ## Build and zip the nomad-driver-podman pl
 	zip -j $@ $(dir $<)*
 
 .PHONY: dev
-dev: check clean build/nomad-driver-podman ## Build the nomad-driver-podman plugin
+dev: clean build/nomad-driver-podman ## Build the nomad-driver-podman plugin
 
 build/nomad-driver-podman:
 	@echo "==> Building driver plugin ..."


### PR DESCRIPTION
This PR removes the `check` step from the `dev` target - when using
a `go.work` file the check step will prevent the dev target from being
succesfull, which makes things tedious when hacking on stuff.

The check target is run as part of CI; we should be fine there.
