### PR TITLE
driver: set cpuset when using cgroups v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ this plugin to Nomad!
 * Monitor the memory consumption
 * Monitor CPU usage
 * Task config cpu value is used to populate podman CpuShares
+* Task config cores value is used to populate podman Cpuset
 * Container log is forwarded to [Nomad logger](https://www.nomadproject.io/docs/commands/alloc/logs.html)
 * Utilize podmans --init feature
 * Set username or UID used for the specified command within the container (podman --user option).

--- a/driver_test.go
+++ b/driver_test.go
@@ -2123,6 +2123,28 @@ func createInspectImage(t *testing.T, image, reference string) {
 	must.Eq(t, idRef, idTest)
 }
 
+func Test_setTaskCpuset(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("empty", func(t *testing.T) {
+		sysResources := &drivers.LinuxResources{CpusetCpus: ""}
+		taskCPU := new(spec.LinuxCPU)
+		cfg := TaskConfig{}
+		err := setCPUResources(cfg, sysResources, taskCPU)
+		must.NoError(t, err)
+		must.Eq(t, "", taskCPU.Cpus)
+	})
+
+	t.Run("non-empty", func(t *testing.T) {
+		sysResources := &drivers.LinuxResources{CpusetCpus: "2,5-8"}
+		taskCPU := new(spec.LinuxCPU)
+		cfg := TaskConfig{}
+		err := setCPUResources(cfg, sysResources, taskCPU)
+		must.NoError(t, err)
+		must.Eq(t, "2,5-8", taskCPU.Cpus)
+	})
+}
+
 func Test_cpuLimits(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
This PR makes it so that the Podman driver will now respect the task
config `resources.cores` value. When set, the task will be assigned the
specified number of CPU cores to be allowed to run on.

Note: unlike the docker/exec drivers, podman tasks will not be also allowed
to make use of the "shared" set of cpu cores (ones that have not yet been
reserved specifically for a task). Most likely that feature will be removed
in the near future (~Nomad 1.7) anyway.

Closes #160