### PR TITLE
driver: add support for configuring extra_hosts in podman tasks

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,7 +46,7 @@ var (
 	})
 
 	// taskConfigSpec is the hcl specification for the driver config section of
-	// a task within a job. It is returned in the TaskConfigSchema RPC
+	// a task within a job. It is returned in the TaskConfigSchema RPC.
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		"apparmor_profile": hclspec.NewAttr("apparmor_profile", "string", false),
 		"args":             hclspec.NewAttr("args", "list(string)", false),
@@ -61,13 +61,10 @@ var (
 		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
 		"cpu_cfs_period": hclspec.NewAttr("cpu_cfs_period", "number", false),
 		"devices":        hclspec.NewAttr("devices", "list(string)", false),
-
-		// Use `any` to maintain backwards compatibility.
-		// Expected type is `list(string)` but may be `string` for old tasks.
-		"entrypoint":  hclspec.NewAttr("entrypoint", "any", false),
-		"working_dir": hclspec.NewAttr("working_dir", "string", false),
-		"hostname":    hclspec.NewAttr("hostname", "string", false),
-		"image":       hclspec.NewAttr("image", "string", true),
+		"entrypoint":     hclspec.NewAttr("entrypoint", "any", false), // any for compat
+		"working_dir":    hclspec.NewAttr("working_dir", "string", false),
+		"hostname":       hclspec.NewAttr("hostname", "string", false),
+		"image":          hclspec.NewAttr("image", "string", true),
 		"image_pull_timeout": hclspec.NewDefault(
 			hclspec.NewAttr("image_pull_timeout", "string", false),
 			hclspec.NewLiteral(`"5m"`),
@@ -83,6 +80,7 @@ var (
 		"memory_swap":        hclspec.NewAttr("memory_swap", "string", false),
 		"memory_swappiness":  hclspec.NewAttr("memory_swappiness", "number", false),
 		"network_mode":       hclspec.NewAttr("network_mode", "string", false),
+		"extra_hosts":        hclspec.NewAttr("extra_hosts", "list(string)", false),
 		"pids_limit":         hclspec.NewAttr("pids_limit", "number", false),
 		"port_map":           hclspec.NewAttr("port_map", "list(map(number))", false),
 		"ports":              hclspec.NewAttr("ports", "list(string)", false),
@@ -134,21 +132,18 @@ type PluginConfig struct {
 
 // TaskConfig is the driver configuration of a task within a job
 type TaskConfig struct {
-	ApparmorProfile string     `codec:"apparmor_profile"`
-	Args            []string   `codec:"args"`
-	Auth            AuthConfig `codec:"auth"`
-	Ports           []string   `codec:"ports"`
-	Tmpfs           []string   `codec:"tmpfs"`
-	Volumes         []string   `codec:"volumes"`
-	CapAdd          []string   `codec:"cap_add"`
-	CapDrop         []string   `codec:"cap_drop"`
-	SelinuxOpts     []string   `codec:"selinux_opts"`
-	Command         string     `codec:"command"`
-	Devices         []string   `codec:"devices"`
-
-	// Use `any` to maintain backwards compatibility.
-	// Expected type is `[]string` but may be `string` for old tasks.
-	Entrypoint        any                `codec:"entrypoint"`
+	ApparmorProfile   string             `codec:"apparmor_profile"`
+	Args              []string           `codec:"args"`
+	Auth              AuthConfig         `codec:"auth"`
+	Ports             []string           `codec:"ports"`
+	Tmpfs             []string           `codec:"tmpfs"`
+	Volumes           []string           `codec:"volumes"`
+	CapAdd            []string           `codec:"cap_add"`
+	CapDrop           []string           `codec:"cap_drop"`
+	SelinuxOpts       []string           `codec:"selinux_opts"`
+	Command           string             `codec:"command"`
+	Devices           []string           `codec:"devices"`
+	Entrypoint        any                `codec:"entrypoint"` // any for compat
 	WorkingDir        string             `codec:"working_dir"`
 	Hostname          string             `codec:"hostname"`
 	Image             string             `codec:"image"`
@@ -159,6 +154,7 @@ type TaskConfig struct {
 	MemoryReservation string             `codec:"memory_reservation"`
 	MemorySwap        string             `codec:"memory_swap"`
 	NetworkMode       string             `codec:"network_mode"`
+	ExtraHosts        []string           `codec:"extra_hosts"`
 	CPUCFSPeriod      uint64             `codec:"cpu_cfs_period"`
 	MemorySwappiness  int64              `codec:"memory_swappiness"`
 	PidsLimit         int64              `codec:"pids_limit"`

--- a/config_test.go
+++ b/config_test.go
@@ -121,3 +121,19 @@ func TestConfig_ImagePullTimeout(t *testing.T) {
 	parser.ParseHCL(t, validHCL, &tc)
 	must.Eq(t, "10m", tc.ImagePullTimeout)
 }
+
+func TestConfig_ExtraHosts(t *testing.T) {
+	ci.Parallel(t)
+
+	parser := hclutils.NewConfigParser(taskConfigSpec)
+	validHCL := `
+		config {
+		image = "docker://redis"
+		extra_hosts = ["myhost:127.0.0.2", "example.com:10.0.0.1"]
+	}
+	`
+
+	var tc *TaskConfig
+	parser.ParseHCL(t, validHCL, &tc)
+	must.Eq(t, []string{"myhost:127.0.0.2", "example.com:10.0.0.1"}, tc.ExtraHosts)
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -618,7 +618,33 @@ func TestPodmanDriver_Hostname(t *testing.T) {
 	// check if the hostname was visible in the container
 	tasklog := readStdoutLog(t, task)
 	must.StrContains(t, tasklog, shouldHaveHostname)
+}
 
+func TestPodmanDriver_setExtraHosts(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		hosts []string
+		exp   error
+	}{{
+		hosts: nil,
+		exp:   nil,
+	}, {
+		hosts: []string{"example.com"},
+		exp:   errors.New("cannot use \"example.com\" as extra_hosts (must be host:ip)"),
+	}, {
+		hosts: []string{"example.com:10.0.0.1"},
+		exp:   nil,
+	}, {
+		hosts: []string{"ip6.example.com:[4321::1234]"},
+		exp:   nil,
+	}}
+
+	for _, tc := range cases {
+		opts := new(api.SpecGenerator)
+		err := setExtraHosts(tc.hosts, opts)
+		must.Eq(t, tc.exp, err)
+	}
 }
 
 // check port_map feature


### PR DESCRIPTION
This PR adds support for setting extra_hosts on in podman task configuration,
bringing the podman driver support up to par with the docker driver.

Closes #244 
