### PR TITLE
repo: setup dependabot to run monthly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,4 +8,4 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - "dependabot"
+      - "theme/dependency"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependabot"


### PR DESCRIPTION
Currently we only get alerts pushed by GitHub security stuff, we should
run dependabot at least once a month just to pick up normal updates.
