### PR TITLE
config: set recover_stopped to default to false

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 )
@@ -33,7 +34,7 @@ var (
 		// allow TaskRecover to start a still existing, stopped, container during client/driver restart
 		"recover_stopped": hclspec.NewDefault(
 			hclspec.NewAttr("recover_stopped", "bool", false),
-			hclspec.NewLiteral("true"),
+			hclspec.NewLiteral("false"),
 		),
 		// optional extra_labels to append to all tasks for observability. Globs supported
 		"extra_labels": hclspec.NewAttr("extra_labels", "list(string)", false),
@@ -128,6 +129,13 @@ type PluginConfig struct {
 	SocketPath           string       `codec:"socket_path"`
 	ClientHttpTimeout    string       `codec:"client_http_timeout"`
 	ExtraLabels          []string     `codec:"extra_labels"`
+}
+
+// LogWarnings will emit logs about known problematic configurations
+func (c *PluginConfig) LogWarnings(logger hclog.Logger) {
+	if c.RecoverStopped {
+		logger.Error("WARNING - use of recover_stopped may cause Nomad agent to not start on system restarts")
+	}
 }
 
 // TaskConfig is the driver configuration of a task within a job

--- a/driver.go
+++ b/driver.go
@@ -225,6 +225,9 @@ func (d *Driver) Capabilities() (*drivers.Capabilities, error) {
 // then send periodic updates at an interval that is appropriate for the driver
 // until the context is canceled.
 func (d *Driver) Fingerprint(ctx context.Context) (<-chan *drivers.Fingerprint, error) {
+	// emit warnings about known bad configs
+	d.config.LogWarnings(d.logger)
+
 	err := shelpers.Init()
 	if err != nil {
 		d.logger.Error("Could not init stats helper", "error", err)


### PR DESCRIPTION
The use of `recover_stopped` may cause the Nomad agent to hang on startup
after node reboot, as the plugin tries to start an exited podman task. 
Podman itself will hang forever in this state, and the http client on the
Nomad side is also unable to timeout in this case. The result is a permanently hung Nomad
agent, until someone force kills either Nomad or Podman.

Also emit a log warning that `recover_stopped` should not be used. We leave
it in place for compatibility.

Fixes #229
