### PR TITLE
config: enable setting tlsVerify during image pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,14 +207,15 @@ config {
 }
 ```
 
-* **auth** - (Optional) Authenticate to the image registry using a static credential.
+* **auth** - (Optional) Authenticate to the image registry using a static credential. `tls_verify` can be disabled for insecure registries.
 
 ```hcl
 config {
   image = "your.registry.tld/some/image"
   auth {
-    username = "someuser"
-    password = "sup3rs3creT"
+    username   = "someuser"
+    password   = "sup3rs3creT"
+    tls_verify = true
   }
 }
 ```

--- a/api/api.go
+++ b/api/api.go
@@ -31,8 +31,9 @@ type ClientConfig struct {
 }
 
 type ImageAuthConfig struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
+	TLSVerify bool
+	Username  string
+	Password  string
 }
 
 func DefaultClientConfig() ClientConfig {

--- a/api/image_pull.go
+++ b/api/image_pull.go
@@ -18,7 +18,8 @@ func (c *API) ImagePull(ctx context.Context, nameWithTag string, auth ImageAuthC
 	headers := map[string]string{}
 
 	// handle authentication
-	if auth.Username != "" && auth.Password != "" {
+	usesAuth := auth.Username != "" && auth.Password != ""
+	if usesAuth {
 		authHeader, err := NewAuthHeader(auth)
 		if err != nil {
 			return "", err
@@ -26,7 +27,10 @@ func (c *API) ImagePull(ctx context.Context, nameWithTag string, auth ImageAuthC
 		headers["X-Registry-Auth"] = authHeader
 	}
 
-	res, err := c.PostWithHeaders(ctx, fmt.Sprintf("/v1.0.0/libpod/images/pull?reference=%s", nameWithTag), nil, headers)
+	c.logger.Trace("image pull details", "tls_verify", auth.TLSVerify, "reference", nameWithTag, "uses_auth", usesAuth)
+
+	urlPath := fmt.Sprintf("/v1.0.0/libpod/images/pull?reference=%s&tlsVerify=%t", nameWithTag, auth.TLSVerify)
+	res, err := c.PostWithHeaders(ctx, urlPath, nil, headers)
 	if err != nil {
 		return "", err
 	}

--- a/config.go
+++ b/config.go
@@ -54,6 +54,10 @@ var (
 		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"username": hclspec.NewAttr("username", "string", false),
 			"password": hclspec.NewAttr("password", "string", false),
+			"tls_verify": hclspec.NewDefault(
+				hclspec.NewAttr("tls_verify", "bool", false),
+				hclspec.NewLiteral("true"),
+			),
 		})),
 		"command":        hclspec.NewAttr("command", "string", false),
 		"cap_add":        hclspec.NewAttr("cap_add", "list(string)", false),
@@ -99,8 +103,9 @@ var (
 
 // AuthConfig is the tasks authentication configuration
 type AuthConfig struct {
-	Username string `codec:"username"`
-	Password string `codec:"password"`
+	Username  string `codec:"username"`
+	Password  string `codec:"password"`
+	TLSVerify bool   `codec:"tls_verify"`
 }
 
 // GCConfig is the driver GarbageCollection configuration

--- a/driver.go
+++ b/driver.go
@@ -952,6 +952,7 @@ func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool, ima
 	}
 
 	d.logger.Info("Pulling image", "image", imageName)
+
 	_ = d.eventer.EmitEvent(&drivers.TaskEvent{
 		TaskID:    cfg.ID,
 		TaskName:  cfg.Name,
@@ -959,9 +960,11 @@ func (d *Driver) createImage(image string, auth *AuthConfig, forcePull bool, ima
 		Timestamp: time.Now(),
 		Message:   "Pulling image " + imageName,
 	})
+
 	imageAuth := api.ImageAuthConfig{
-		Username: auth.Username,
-		Password: auth.Password,
+		TLSVerify: auth.TLSVerify,
+		Username:  auth.Username,
+		Password:  auth.Password,
 	}
 
 	result, err, _ := d.pullGroup.Do(imageName, func() (interface{}, error) {


### PR DESCRIPTION
By default podman (and docker) assume an image registry is configured
to serve via HTTPS. By setting the tlsVerify=false query parameter we
can make use of registries serving via HTTP, which is helpful e.g. in
e2e tests.
