### PR TITLE
driver: support for credentials helper and auth config file

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,8 +5,6 @@ package api
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -28,12 +26,6 @@ type API struct {
 type ClientConfig struct {
 	SocketPath  string
 	HttpTimeout time.Duration
-}
-
-type ImageAuthConfig struct {
-	TLSVerify bool
-	Username  string
-	Password  string
 }
 
 func DefaultClientConfig() ClientConfig {
@@ -122,16 +114,6 @@ func (c *API) Delete(ctx context.Context, path string) (*http.Response, error) {
 		return nil, err
 	}
 	return c.Do(req)
-}
-
-// NewAuthHeader encodes auth configuration to a docker X-Registry-Auth header payload.
-func NewAuthHeader(auth ImageAuthConfig) (string, error) {
-	jsonBytes, err := json.Marshal(auth)
-	if err != nil {
-		return "", err
-	}
-	header := base64.StdEncoding.EncodeToString(jsonBytes)
-	return header, nil
 }
 
 func ignoreClose(c io.Closer) {

--- a/api/image_pull_test.go
+++ b/api/image_pull_test.go
@@ -6,13 +6,16 @@ package api
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/nomad-driver-podman/registry"
 	"github.com/shoenig/test/must"
 )
 
 func TestApi_Image_Pull(t *testing.T) {
 	api := newApi()
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
 
 	testCases := []struct {
 		Image  string
@@ -25,7 +28,9 @@ func TestApi_Image_Pull(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		id, err := api.ImagePull(ctx, testCase.Image, ImageAuthConfig{})
+		id, err := api.ImagePull(ctx, &registry.PullConfig{
+			Image: testCase.Image,
+		})
 		if testCase.Exists {
 			must.NoError(t, err)
 			must.NotEq(t, "", id)

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ var (
 		// image registry authentication options
 		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"config": hclspec.NewAttr("config", "string", false),
+			"helper": hclspec.NewAttr("helper", "string", false),
 		})),
 
 		// volume options
@@ -107,9 +108,9 @@ var (
 	})
 )
 
-// AuthConfig is the tasks authentication configuration
+// TaskAuthConfig is the tasks authentication configuration
 // (there is also auth_soft_fail on the top level)
-type AuthConfig struct {
+type TaskAuthConfig struct {
 	Username  string `codec:"username"`
 	Password  string `codec:"password"`
 	TLSVerify bool   `codec:"tls_verify"`
@@ -132,15 +133,21 @@ type VolumeConfig struct {
 	SelinuxLabel string `codec:"selinuxlabel"`
 }
 
+type PluginAuthConfig struct {
+	FileConfig string `codec:"config"`
+	Helper     string `codec:"helper"`
+}
+
 // PluginConfig is the driver configuration set by the SetConfig RPC call
 type PluginConfig struct {
-	Volumes              VolumeConfig `codec:"volumes"`
-	GC                   GCConfig     `codec:"gc"`
-	RecoverStopped       bool         `codec:"recover_stopped"`
-	DisableLogCollection bool         `codec:"disable_log_collection"`
-	SocketPath           string       `codec:"socket_path"`
-	ClientHttpTimeout    string       `codec:"client_http_timeout"`
-	ExtraLabels          []string     `codec:"extra_labels"`
+	Auth                 PluginAuthConfig `codec:"auth"`
+	Volumes              VolumeConfig     `codec:"volumes"`
+	GC                   GCConfig         `codec:"gc"`
+	RecoverStopped       bool             `codec:"recover_stopped"`
+	DisableLogCollection bool             `codec:"disable_log_collection"`
+	SocketPath           string           `codec:"socket_path"`
+	ClientHttpTimeout    string           `codec:"client_http_timeout"`
+	ExtraLabels          []string         `codec:"extra_labels"`
 }
 
 // LogWarnings will emit logs about known problematic configurations
@@ -154,7 +161,7 @@ func (c *PluginConfig) LogWarnings(logger hclog.Logger) {
 type TaskConfig struct {
 	ApparmorProfile   string             `codec:"apparmor_profile"`
 	Args              []string           `codec:"args"`
-	Auth              AuthConfig         `codec:"auth"`
+	Auth              TaskAuthConfig     `codec:"auth"`
 	AuthSoftFail      bool               `codec:"auth_soft_fail"`
 	Ports             []string           `codec:"ports"`
 	Tmpfs             []string           `codec:"tmpfs"`

--- a/config.go
+++ b/config.go
@@ -12,6 +12,11 @@ import (
 var (
 	// configSpec is the hcl specification returned by the ConfigSchema RPC
 	configSpec = hclspec.NewObject(map[string]*hclspec.Spec{
+		// image registry authentication options
+		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
+			"config": hclspec.NewAttr("config", "string", false),
+		})),
+
 		// volume options
 		"volumes": hclspec.NewDefault(hclspec.NewBlock("volumes", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"enabled": hclspec.NewDefault(
@@ -59,6 +64,7 @@ var (
 				hclspec.NewLiteral("true"),
 			),
 		})),
+		"auth_soft_fail": hclspec.NewAttr("auth_soft_fail", "bool", false),
 		"command":        hclspec.NewAttr("command", "string", false),
 		"cap_add":        hclspec.NewAttr("cap_add", "list(string)", false),
 		"cap_drop":       hclspec.NewAttr("cap_drop", "list(string)", false),
@@ -102,6 +108,7 @@ var (
 )
 
 // AuthConfig is the tasks authentication configuration
+// (there is also auth_soft_fail on the top level)
 type AuthConfig struct {
 	Username  string `codec:"username"`
 	Password  string `codec:"password"`
@@ -148,6 +155,7 @@ type TaskConfig struct {
 	ApparmorProfile   string             `codec:"apparmor_profile"`
 	Args              []string           `codec:"args"`
 	Auth              AuthConfig         `codec:"auth"`
+	AuthSoftFail      bool               `codec:"auth_soft_fail"`
 	Ports             []string           `codec:"ports"`
 	Tmpfs             []string           `codec:"tmpfs"`
 	Volumes           []string           `codec:"volumes"`

--- a/driver_test.go
+++ b/driver_test.go
@@ -1983,7 +1983,7 @@ func startDestroyInspectImage(t *testing.T, image string, taskName string) {
 		AllocID:   uuid.Generate(),
 		Resources: createBasicResources(),
 	}
-	imageID, err := getPodmanDriver(t, d).createImage(image, &AuthConfig{}, false, 5*time.Minute, task)
+	imageID, err := getPodmanDriver(t, d).createImage(image, &TaskAuthConfig{}, false, false, 5*time.Minute, task)
 	must.NoError(t, err)
 	must.Eq(t, imageID, inspectData.Image)
 }
@@ -2063,7 +2063,7 @@ insecure = true`
 	go func() {
 		// Pull image using our proxy.
 		image := "localhost:5000/quay/busybox:latest"
-		_, err = getPodmanDriver(t, d).createImage(image, &AuthConfig{}, true, 3*time.Second, task)
+		_, err = getPodmanDriver(t, d).createImage(image, &TaskAuthConfig{}, false, true, 3*time.Second, task)
 		resultCh <- err
 	}()
 
@@ -2141,7 +2141,7 @@ func createInspectImage(t *testing.T, image, reference string) {
 		AllocID:   uuid.Generate(),
 		Resources: createBasicResources(),
 	}
-	idTest, err := getPodmanDriver(t, d).createImage(image, &AuthConfig{}, false, 5*time.Minute, task)
+	idTest, err := getPodmanDriver(t, d).createImage(image, &TaskAuthConfig{}, false, false, 5*time.Minute, task)
 	must.NoError(t, err)
 
 	idRef, err := getPodmanDriver(t, d).podman.ImageInspectID(context.Background(), reference)

--- a/registry/authentication.go
+++ b/registry/authentication.go
@@ -77,7 +77,6 @@ func (pc *PullConfig) Log(logger hclog.Logger) {
 		token = r.IdentityToken != ""
 	}
 
-	// todo: trace
 	logger.Info("pull config",
 		"repository", repository,
 		"username", username,

--- a/registry/authentication.go
+++ b/registry/authentication.go
@@ -1,0 +1,157 @@
+package registry
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+// PullConfig represents the necessary information needed for an image pull query.
+type PullConfig struct {
+	Repository     string
+	RegistryConfig *RegistryAuthConfig
+	TLSVerify      bool
+
+	// TODO: config file
+	// TODO: creds helper
+}
+
+// BasicConfig returns the Basic-Auth level of configuration.
+//
+// For the podman driver, this is what can be supplied in the task config block.
+func (pc *PullConfig) BasicConfig() *TaskAuthConfig {
+	if pc == nil || pc.RegistryConfig == nil {
+		return nil
+	}
+	return &TaskAuthConfig{
+		Username:      pc.RegistryConfig.Username,
+		Password:      pc.RegistryConfig.Password,
+		Email:         pc.RegistryConfig.Email,
+		ServerAddress: pc.RegistryConfig.ServerAddress,
+	}
+}
+
+// Log the components of PullConfig in a safe way.
+func (pc *PullConfig) Log(logger hclog.Logger) {
+	var (
+		repository = pc.Repository
+		tls        bool
+		username   = "<unset>"
+		email      = "<unset>"
+		server     = "<unset>"
+		password   bool
+		token      bool
+	)
+
+	if r := pc.RegistryConfig; r != nil {
+		tls = pc.TLSVerify
+		username = r.Username
+		email = r.Email
+		server = r.ServerAddress
+		password = r.Password != ""
+		token = r.IdentityToken != ""
+	}
+
+	// todo: trace
+	logger.Info("pull config",
+		"repository", repository,
+		"username", username,
+		"password", password,
+		"email", email,
+		"server", server,
+		"tls", tls,
+		"token", token,
+	)
+}
+
+// RegistryAuthConfig represents the actualized authentication for accessing a
+// container registry.
+//
+// Note that IdentityToken is mutually exclusive with the remaining fields.
+type RegistryAuthConfig struct {
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Email         string `json:"email,omitempty"`
+	ServerAddress string `json:"serveraddress,omitempty"`
+	IdentityToken string `json:"identitytoken,omitempty"`
+}
+
+// SetHeader will apply the X-Registry-Auth header (if necessary) to headers.
+func (r *RegistryAuthConfig) SetHeader(headers map[string]string) {
+	if !r.Empty() {
+		b, err := json.Marshal(r)
+		if err != nil {
+			return
+		}
+		header := base64.StdEncoding.EncodeToString(b)
+		headers["X-Registry-Auth"] = header
+	}
+}
+
+// Empty returns true if all of username, password, and identity token are unset.
+func (r *RegistryAuthConfig) Empty() bool {
+	return r == nil || (r.Username == "" && r.Password == "" && r.IdentityToken == "")
+}
+
+// TaskAuthConfig represents the "auth" section of the config block for
+// the podman task driver.
+type TaskAuthConfig struct {
+	Username      string
+	Password      string
+	Email         string
+	ServerAddress string
+}
+
+func (c *TaskAuthConfig) IsEmpty() bool {
+	return c == nil || (c.Username == "" && c.Password == "")
+}
+
+// ResolveRegistryAuthentication will find a compatible AuthBackend for the given repository.
+// In order, try using
+// - auth block from task
+// - auth from auth.json file specified by plugin config
+// - auth from a credentials helper specified by plugin config
+func ResolveRegistryAuthentication(repository string, pullConfig *PullConfig) (*RegistryAuthConfig, error) {
+	return firstValidAuth(repository, []AuthBackend{
+		authFromTaskConfig(pullConfig.BasicConfig()),
+	})
+}
+
+// An AuthBackend is a function that resolves registry credentials for a given
+// repository. If no auth exitsts for the given repository, (nil, nil) is
+// returned and should be skipped.
+type AuthBackend func(string) (*RegistryAuthConfig, error)
+
+func firstValidAuth(repository string, authBackends []AuthBackend) (*RegistryAuthConfig, error) {
+	for _, backend := range authBackends {
+		auth, err := backend(repository)
+		if auth != nil || err != nil {
+			return auth, err
+		}
+	}
+	return nil, nil
+}
+
+func authFromTaskConfig(taskAuthConfig *TaskAuthConfig) AuthBackend {
+	return func(string) (*RegistryAuthConfig, error) {
+		if taskAuthConfig.IsEmpty() {
+			return nil, nil
+		}
+		return &RegistryAuthConfig{
+			Username:      taskAuthConfig.Username,
+			Password:      taskAuthConfig.Password,
+			Email:         taskAuthConfig.Email,
+			ServerAddress: taskAuthConfig.ServerAddress,
+		}, nil
+	}
+}
+
+func authFromFileConfig(filename string) (*RegistryAuthConfig, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
+func authFromCredsHelper(helper string) (*RegistryAuthConfig, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}

--- a/registry/authentication_test.go
+++ b/registry/authentication_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestPullConfig_NoAuth(t *testing.T) {
+	cases := []struct {
+		name string
+		pc   *PullConfig
+		exp  bool
+	}{
+		{
+			name: "task config",
+			pc: &PullConfig{
+				RegistryConfig: &RegistryAuthConfig{
+					Username: "user",
+					Password: "pass",
+				},
+			},
+			exp: true,
+		},
+		{
+			name: "creds helper",
+			pc: &PullConfig{
+				CredentialsHelper: "helper.sh",
+			},
+			exp: true,
+		},
+		{
+			name: "creds file",
+			pc: &PullConfig{
+				CredentialsFile: "auth.json",
+			},
+			exp: true,
+		},
+		{
+			name: "none",
+			pc:   &PullConfig{},
+			exp:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.pc.AuthAvailable()
+			must.Eq(t, tc.exp, result)
+		})
+	}
+}

--- a/registry/credshelper.go
+++ b/registry/credshelper.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	// helperTimeout is the maximum amount of time to allow a credential helper
+	// to execute before force killing it
+	helperTimeout = 10 * time.Second
+)
+
+func helpCmd(ctx context.Context, name, index string) (*exec.Cmd, error) {
+	executable := fmt.Sprintf("docker-credential-%s", name)
+
+	path, err := exec.LookPath(executable)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Args = []string{"get"}
+	cmd.Stdin = strings.NewReader(index)
+	return cmd, nil
+}
+
+type Credential struct {
+	Username string `json:"Username"`
+	Secret   string `json:"Secret"`
+}
+
+func (c *Credential) Empty() bool {
+	return c == nil || (c.Username == "" && c.Secret == "")
+}
+
+func authFromCredsHelper(name string) AuthBackend {
+	if name == "" {
+		return noBackend
+	}
+	return func(repository string) (*RegistryAuthConfig, error) {
+		repo := parse(repository)
+		index := repo.Index()
+
+		ctx, cancel := context.WithTimeout(context.Background(), helperTimeout)
+		defer cancel()
+
+		cmd, err := helpCmd(ctx, name, index)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("failed to run credential-helper %q: %w", name, err)
+		}
+
+		var credential Credential
+		if err := json.Unmarshal(b, &credential); err != nil {
+			return nil, fmt.Errorf("failed to read credential from credential-helper %q: %w", name, err)
+		}
+
+		if credential.Empty() {
+			return nil, nil
+		}
+
+		return &RegistryAuthConfig{
+			Username: credential.Username,
+			Password: credential.Secret,
+		}, nil
+	}
+}

--- a/registry/credshelper_test.go
+++ b/registry/credshelper_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"os"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func Test_authFromCredsHelper(t *testing.T) {
+	cases := []struct {
+		name       string
+		repository string
+		exp        *RegistryAuthConfig
+	}{
+		{
+			name:       "basic",
+			repository: "docker.io/library/bash:5",
+			exp: &RegistryAuthConfig{
+				Username: "user1",
+				Password: "pass1",
+			},
+		},
+		{
+			name:       "example.com",
+			repository: "example.com/some/silly/thing:v1",
+			exp: &RegistryAuthConfig{
+				Username: "user2",
+				Password: "pass2",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PATH", os.ExpandEnv("${PWD}/tests:${PATH}"))
+			be := authFromCredsHelper("fake.sh")
+			rac, err := be(tc.repository)
+			must.NoError(t, err)
+			must.Eq(t, tc.exp, rac)
+		})
+	}
+}

--- a/registry/fileconfig.go
+++ b/registry/fileconfig.go
@@ -8,7 +8,7 @@ import (
 	"os"
 )
 
-// [Glossery]
+// [Glossary]
 // registry: The service that serves container images.
 // domain: The DNS domain name of a registry.
 // repository: The domain + complete path of an image (no tag).

--- a/registry/fileconfig.go
+++ b/registry/fileconfig.go
@@ -1,0 +1,87 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// [Glossery]
+// registry: The service that serves container images.
+// domain: The DNS domain name of a registry.
+// repository: The domain + complete path of an image (no tag).
+// index: The domain[+[sub]path] of an image (no tag) (i.e. repository prefix).
+// image: A complete domain + path + tag
+// credential: A base64 encoded username + password associated with an index.
+
+// CredentialsFile is the struct that represents the contents of the "auth.json" file
+// that stores or references credentials that enable authentication into specific
+// registries or even repositories.
+//
+// reference: https://www.mankier.com/5/containers-auth.json
+// alternate: https://man.archlinux.org/man/containers-auth.json.5
+type CredentialsFile struct {
+	Auths map[string]EncAuth `json:"auths"`
+
+	// CredHelpers is currently not supported by the podman task driver
+	// CredHelpers map[string]string  `json:"credHelpers"`
+}
+
+// EncAuth represents a single registry (or specific repository) and the associated
+// base64 encoded auth token.
+type EncAuth struct {
+	Auth string `json:"auth"`
+}
+
+func authFromFileConfig(filename string) AuthBackend {
+	return func(repository string) (*RegistryAuthConfig, error) {
+		repo := parse(repository)
+
+		cFile, err := loadCredentialsFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		rac := cFile.lookup(repo)
+		return rac, nil
+	}
+}
+
+func loadCredentialsFile(path string) (*CredentialsFile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cFile CredentialsFile
+
+	dec := json.NewDecoder(f)
+	if err := dec.Decode(&cFile); err != nil {
+		return nil, err
+	}
+	return &cFile, nil
+}
+
+func (cf *CredentialsFile) lookup(repository *ImageSpecs) *RegistryAuthConfig {
+	if cf == nil {
+		return nil
+	}
+
+	// first look for any static auth that applies
+	for index, credential := range cf.Auths {
+		if repository.Match(index) {
+			user, pass := decode(credential.Auth)
+			return &RegistryAuthConfig{
+				Username: user,
+				Password: pass,
+			}
+		}
+	}
+
+	// TODO: add support for specifying credentials helpers that can be used
+	// via credsHelpers in this credentials file.
+
+	return nil
+}

--- a/registry/fileconfig_test.go
+++ b/registry/fileconfig_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func Test_authFromConfigFile(t *testing.T) {
+	ab := authFromFileConfig("tests/auth.json")
+	must.NotNil(t, ab)
+
+	cases := []struct {
+		name    string
+		image   string
+		expUser string
+		expPass string
+	}{
+		{
+			name:    "complete",
+			image:   "one.example.com/library/bash:5",
+			expUser: "user1",
+			expPass: "pass1",
+		},
+		{
+			name:    "partial path",
+			image:   "two.example.com/library/bash:5",
+			expUser: "user2",
+			expPass: "pass2",
+		},
+		{
+			name:    "domain only",
+			image:   "three.example.com/library/bash:5",
+			expUser: "user3",
+			expPass: "pass3",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rac, err := ab(tc.image)
+			must.NoError(t, err)
+			must.NotNil(t, rac, must.Sprintf("RAC should not be nil"))
+			must.Eq(t, tc.expUser, rac.Username)
+			must.Eq(t, tc.expPass, rac.Password)
+		})
+	}
+}

--- a/registry/tests/auth.json
+++ b/registry/tests/auth.json
@@ -1,0 +1,14 @@
+{
+  "auths": {
+    "one.example.com/library/bash": {
+     "auth": "dXNlcjE6cGFzczE="
+    },
+    "two.example.com/library": {
+      "auth": "dXNlcjI6cGFzczI="
+    },
+    "three.example.com": {
+      "auth": "dXNlcjM6cGFzczM="
+    }
+  }
+}
+

--- a/registry/tests/docker-credential-fake.sh
+++ b/registry/tests/docker-credential-fake.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+value=$(cat /dev/stdin)
+
+case "${value}" in
+  docker.io/*)
+    username="user1"
+    password="pass1"
+    ;;
+  example.com/*)
+    username="user2"
+    password="pass2"
+    ;;
+  *)
+    echo "unknown"
+    exit 1
+    ;;
+esac
+
+echo "{\"Username\": \"$username\", \"Secret\": \"$password\"}"
+

--- a/registry/util.go
+++ b/registry/util.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// noBackend may be used when it is known no AuthBackend exists
+// that can be used.
+func noBackend(string) (*RegistryAuthConfig, error) {
+	return nil, nil
+}
+
+// ImageSpecs holds each of the components of a full container image identifier,
+// such that we can ask questions about it. There are three parts,
+// - domain
+// - path
+// - tag
+type ImageSpecs struct {
+	Domain string
+	Path   []string
+	Tag    string
+}
+
+func (is *ImageSpecs) Index() string {
+	s := []string{is.Domain}
+	s = append(s, is.Path...)
+	return strings.Join(s, "/")
+}
+
+// Match returns true if the repository belongs to the given registry index.
+//
+// Given repository example.com/foo/bar, each of these index values would
+// match, e.g.
+// - example.com
+// - examle.com/foo
+// - example.com/foo/bar
+//
+// Whereas other index values would not match, e.g.
+// - other.com
+// - example.com/baz
+// - example.com/foo/bar/baz
+func (is *ImageSpecs) Match(index string) bool {
+	repository := is.Index()
+	if len(index) > len(repository) {
+		return false
+	}
+	if strings.HasPrefix(repository, index) {
+		return true
+	}
+	return false
+}
+
+// parse the repository string into a useful object we can interact with to
+// ask questions about that repository
+func parse(repository string) *ImageSpecs {
+	repository = strings.TrimPrefix(repository, "https://")
+	repository = strings.TrimPrefix(repository, "http://")
+	tagIdx := strings.LastIndex(repository, ":")
+	var tag string
+	if tagIdx != -1 {
+		tag = repository[tagIdx+1:]
+		repository = repository[0:tagIdx]
+	}
+	if tag == "" {
+		tag = "latest"
+	}
+	parts := strings.Split(repository, "/")
+	return &ImageSpecs{
+		Domain: parts[0],
+		Path:   parts[1:],
+		Tag:    tag,
+	}
+}
+
+func decode(b64 string) (string, string) {
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return "", ""
+	}
+	parts := strings.SplitN(string(data), ":", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}

--- a/registry/util_test.go
+++ b/registry/util_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func Test_parse(t *testing.T) {
+	cases := []struct {
+		name       string
+		repository string
+		exp        *ImageSpecs
+	}{
+		{
+			name:       "normal format",
+			repository: "docker.io/library/bash:5",
+			exp: &ImageSpecs{
+				Domain: "docker.io",
+				Path:   []string{"library", "bash"},
+				Tag:    "5",
+			},
+		},
+		{
+			name:       "no tag",
+			repository: "docker.io/library/bash",
+			exp: &ImageSpecs{
+				Domain: "docker.io",
+				Path:   []string{"library", "bash"},
+				Tag:    "latest",
+			},
+		},
+		{
+			name:       "http prefix",
+			repository: "http://docker.io/library/bash:5",
+			exp: &ImageSpecs{
+				Domain: "docker.io",
+				Path:   []string{"library", "bash"},
+				Tag:    "5",
+			},
+		},
+		{
+			name:       "https prefix",
+			repository: "https://docker.io/library/bash:5",
+			exp: &ImageSpecs{
+				Domain: "docker.io",
+				Path:   []string{"library", "bash"},
+				Tag:    "5",
+			},
+		},
+		{
+			name:       "single path element",
+			repository: "example.com/app:version",
+			exp: &ImageSpecs{
+				Domain: "example.com",
+				Path:   []string{"app"},
+				Tag:    "version",
+			},
+		},
+		{
+			name:       "triple path element",
+			repository: "example.com/one/two/three:v1",
+			exp: &ImageSpecs{
+				Domain: "example.com",
+				Path:   []string{"one", "two", "three"},
+				Tag:    "v1",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := parse(tc.repository)
+			must.Eq(t, tc.exp, repo)
+		})
+	}
+}
+
+func TestRepository_Match(t *testing.T) {
+	cases := []struct {
+		name       string
+		repository string
+		index      string
+		exp        bool
+	}{
+		{
+			name:       "exact",
+			repository: "docker.io/library/bash",
+			index:      "docker.io/library/bash",
+			exp:        true,
+		},
+		{
+			name:       "domain",
+			repository: "docker.io/library/bash",
+			index:      "docker.io",
+			exp:        true,
+		},
+		{
+			name:       "sub path",
+			repository: "docker.io/library/bash",
+			index:      "docker.io/library",
+			exp:        true,
+		},
+		{
+			name:       "wrong domain",
+			repository: "docker.io/library/bash",
+			index:      "other.com",
+			exp:        false,
+		},
+		{
+			name:       "wrong path",
+			repository: "docker.io/library/bash",
+			index:      "docker.io/other/bash",
+			exp:        false,
+		},
+		{
+			name:       "extended path",
+			repository: "docker.io/library/bash",
+			index:      "docker.io/library/bash/other",
+			exp:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := parse(tc.repository)
+			result := repo.Match(tc.index)
+			must.Eq(t, tc.exp, result, must.Sprintf(
+				"expect %t, repository: %s, index: %s",
+				tc.exp,
+				tc.repository,
+				tc.index,
+			))
+		})
+	}
+}
+
+func Test_decode(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		expUser string
+		expPass string
+	}{
+		{
+			name:    "ok",
+			input:   "dXNlcjE6cGFzczE=",
+			expUser: "user1",
+			expPass: "pass1",
+		},
+		{
+			name:  "no split",
+			input: "dXNlcjE=",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, pass := decode(tc.input)
+			must.Eq(t, tc.expUser, user)
+			must.Eq(t, tc.expPass, pass)
+		})
+	}
+}


### PR DESCRIPTION
  This PR adds support for specifying an external credentials helper and/
  or an external credentials file (e.g. "auth.json"). The plugin configuration
  now has an `auth` block with fields `helper` and `config` (similar to
  the docker driver). We also now have an `auth_soft_fail` option in Task
  config for cases where someone has configured the `auth` block in plugin
  config, but has a task that is using a public image with no credentials.
  In that case setting `auth_soft_fail` is used to ignore the fact that
  no credentials will be found for the given public image. (This is also
  how the docker driver works, I didn't come up with this).

  Unlike the docker driver, the podman driver still does not support
  specifying a credentials helper _in_ the external "auth.json"
  credentials file. If there is demand for that use case we can add
  it, but in the short term it seems like just the plugin's support for
  specifying a credentials helper could be sufficient. And it's a lot of
  code to do the other thing.

Closes #132
Closes #174

Note: docs and changelog will be in a follow up PR (along with all the other 0.5.0 work).

e2e tests will be in https://github.com/hashicorp/nomad/commits/e2e-podman-private-registry
(still needs to tweaking to work with the actual e2e runner)