### PR TITLE
Added a plugin logging configuration to specify defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+
+ * config: Add `logging` options to the plugin configuration [[GH-285](https://github.com/hashicorp/nomad-driver-podman/pull/285)]
+
 ## 0.5.2 (February 5, 2024)
 
 SECURITY:

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ plugin "nomad-driver-podman" {
 }
 ```
 
+* logging stanza:
+
+  * type - Defaults to `"nomad"`. See the task configuration for details.
+  * options - Defaults to `{}`. See the task configuration for details.
+
 * client_http_timeout (string) Defaults to `60s` default timeout used by http.Client requests
 
 ```hcl
@@ -342,11 +347,9 @@ Ensure you're running Podman 3.1.0 or higher because of bugs in older versions.
 config {
   logging = {
     driver = "journald"
-    options = [
-      {
-        "tag" = "redis"
-      }
-    ]
+    options = {
+      "tag" = "redis"
+    }
   }
 }
 ```

--- a/compat/nomad/client/stats/cpu.go
+++ b/compat/nomad/client/stats/cpu.go
@@ -1,0 +1,147 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stats
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/nomad-driver-podman/compat/nomad/helper/stats"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shoenig/go-m1cpu"
+)
+
+const (
+	// cpuInfoTimeout is the timeout used when gathering CPU info. This is used
+	// to override the default timeout in gopsutil which has a tendency to
+	// timeout on Windows.
+	cpuInfoTimeout = 60 * time.Second
+)
+
+var (
+	cpuPowerCoreCount      int
+	cpuPowerCoreMHz        uint64
+	cpuEfficiencyCoreCount int
+	cpuEfficiencyCoreMHz   uint64
+	cpuModelName           string
+)
+
+var (
+	detectedCpuTotalTicks uint64
+	initErr               error
+	onceLer               sync.Once
+)
+
+func Init(configCpuTotalCompute uint64) error {
+	onceLer.Do(func() {
+		switch {
+		case m1cpu.IsAppleSilicon():
+			cpuModelName = m1cpu.ModelName()
+			cpuPowerCoreCount = m1cpu.PCoreCount()
+			cpuPowerCoreMHz = m1cpu.PCoreHz() / 1_000_000
+			cpuEfficiencyCoreCount = m1cpu.ECoreCount()
+			cpuEfficiencyCoreMHz = m1cpu.ECoreHz() / 1_000_000
+			bigTicks := uint64(cpuPowerCoreCount) * cpuPowerCoreMHz
+			littleTicks := uint64(cpuEfficiencyCoreCount) * cpuEfficiencyCoreMHz
+			detectedCpuTotalTicks = bigTicks + littleTicks
+		default:
+			// for now, all other cpu types assume only power cores
+			// todo: this is already not true for Intel 13th generation
+
+			var err error
+			if cpuPowerCoreCount, err = cpu.Counts(true); err != nil {
+				initErr = errors.Join(initErr, fmt.Errorf("failed to detect number of CPU cores: %w", err))
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), cpuInfoTimeout)
+			defer cancel()
+
+			var cpuInfoStats []cpu.InfoStat
+			if cpuInfoStats, err = cpu.InfoWithContext(ctx); err != nil {
+				initErr = errors.Join(initErr, fmt.Errorf("Unable to obtain CPU information: %w", err))
+			}
+
+			for _, infoStat := range cpuInfoStats {
+				cpuModelName = infoStat.ModelName
+				if uint64(infoStat.Mhz) > cpuPowerCoreMHz {
+					cpuPowerCoreMHz = uint64(infoStat.Mhz)
+				}
+			}
+
+			// compute ticks using only power core, until we add support for
+			// detecting little cores on non-apple platforms
+			detectedCpuTotalTicks = uint64(cpuPowerCoreCount) * cpuPowerCoreMHz
+
+			initErr = err
+		}
+
+		stats.SetCpuTotalTicks(detectedCpuTotalTicks)
+	})
+
+	// override the computed value with the config value if it is set
+	if configCpuTotalCompute > 0 {
+		stats.SetCpuTotalTicks(configCpuTotalCompute)
+	}
+
+	return initErr
+}
+
+// CPUNumCores returns the number of CPU cores available.
+//
+// This is represented with two values - (Power (P), Efficiency (E)) so we can
+// correctly compute total compute for processors with asymetric cores such as
+// Apple Silicon.
+//
+// For platforms with symetric cores (or where we do not correcly detect asymetric
+// cores), all cores are presented as P cores.
+func CPUNumCores() (int, int) {
+	return cpuPowerCoreCount, cpuEfficiencyCoreCount
+}
+
+// CPUMHzPerCore returns the MHz per CPU (P, E) core type.
+//
+// As with CPUNumCores, asymetric core detection currently only works with
+// Apple Silicon CPUs.
+func CPUMHzPerCore() (uint64, uint64) {
+	return cpuPowerCoreMHz, cpuEfficiencyCoreMHz
+}
+
+// CPUModelName returns the model name of the CPU.
+func CPUModelName() string {
+	return cpuModelName
+}
+
+func (h *HostStatsCollector) collectCPUStats() (cpus []*CPUStats, totalTicks float64, err error) {
+
+	ticksConsumed := 0.0
+	cpuStats, err := cpu.Times(true)
+	if err != nil {
+		return nil, 0.0, err
+	}
+	cs := make([]*CPUStats, len(cpuStats))
+	for idx, cpuStat := range cpuStats {
+		percentCalculator, ok := h.statsCalculator[cpuStat.CPU]
+		if !ok {
+			percentCalculator = NewHostCpuStatsCalculator()
+			h.statsCalculator[cpuStat.CPU] = percentCalculator
+		}
+		idle, user, system, total := percentCalculator.Calculate(cpuStat)
+		ticks := (total / 100.0) * (float64(stats.CpuTotalTicks()) / float64(len(cpuStats)))
+		cs[idx] = &CPUStats{
+			CPU:          cpuStat.CPU,
+			User:         user,
+			System:       system,
+			Idle:         idle,
+			TotalPercent: total,
+			TotalTicks:   ticks,
+		}
+		ticksConsumed += ticks
+	}
+
+	return cs, ticksConsumed, nil
+}

--- a/compat/nomad/client/stats/cpu_darwin_test.go
+++ b/compat/nomad/client/stats/cpu_darwin_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build darwin && arm64 && cgo
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestCPU_Init(t *testing.T) {
+	must.NoError(t, Init())
+}
+
+func TestCPU_CPUNumCores(t *testing.T) {
+	big, little := CPUNumCores()
+	must.Between(t, 4, big, 32)
+	must.Between(t, 2, little, 8)
+}
+
+func TestCPU_CPUMHzPerCore(t *testing.T) {
+	big, little := CPUMHzPerCore()
+	must.Between(t, 3_000, big, 6_000)
+	must.Between(t, 2_000, little, 4_000)
+}
+
+func TestCPU_CPUModelName(t *testing.T) {
+	name := CPUModelName()
+	must.NotEq(t, "", name)
+}
+
+func TestCPU_CPUCpuTotalTicks(t *testing.T) {
+	ticks := CpuTotalTicks()
+	must.Positive(t, ticks)
+}

--- a/compat/nomad/client/stats/cpu_test.go
+++ b/compat/nomad/client/stats/cpu_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stats
+
+import (
+	"math"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostStats_CPU(t *testing.T) {
+	ci.Parallel(t)
+
+	assert := assert.New(t)
+	assert.Nil(Init(0))
+
+	logger := testlog.HCLogger(t)
+	cwd, err := os.Getwd()
+	assert.Nil(err)
+	hs := NewHostStatsCollector(logger, cwd, nil)
+
+	// Collect twice so we can calculate percents we need to generate some work
+	// so that the cpu values change
+	assert.Nil(hs.Collect())
+	total := 0
+	for i := 1; i < 1000000000; i++ {
+		total *= i
+		total = total % i
+	}
+	assert.Nil(hs.Collect())
+	stats := hs.Stats()
+
+	assert.NotZero(stats.CPUTicksConsumed)
+	assert.NotZero(len(stats.CPU))
+
+	for _, cpu := range stats.CPU {
+		assert.False(math.IsNaN(cpu.Idle))
+		assert.False(math.IsNaN(cpu.TotalPercent))
+		assert.False(math.IsNaN(cpu.TotalTicks))
+		assert.False(math.IsNaN(cpu.System))
+		assert.False(math.IsNaN(cpu.User))
+
+		assert.False(math.IsInf(cpu.Idle, 0))
+		assert.False(math.IsInf(cpu.TotalPercent, 0))
+		assert.False(math.IsInf(cpu.TotalTicks, 0))
+		assert.False(math.IsInf(cpu.System, 0))
+		assert.False(math.IsInf(cpu.User, 0))
+	}
+}

--- a/compat/nomad/client/stats/host.go
+++ b/compat/nomad/client/stats/host.go
@@ -1,0 +1,310 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stats
+
+import (
+	"math"
+	"runtime"
+	"sync"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/plugins/device"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/mem"
+)
+
+// HostStats represents resource usage stats of the host running a Nomad client
+type HostStats struct {
+	Memory           *MemoryStats
+	CPU              []*CPUStats
+	DiskStats        []*DiskStats
+	AllocDirStats    *DiskStats
+	DeviceStats      []*DeviceGroupStats
+	Uptime           uint64
+	Timestamp        int64
+	CPUTicksConsumed float64
+}
+
+// MemoryStats represents stats related to virtual memory usage
+type MemoryStats struct {
+	Total     uint64
+	Available uint64
+	Used      uint64
+	Free      uint64
+}
+
+// CPUStats represents stats related to cpu usage
+type CPUStats struct {
+	CPU          string
+	User         float64
+	System       float64
+	Idle         float64
+	TotalPercent float64
+	TotalTicks   float64
+}
+
+// DiskStats represents stats related to disk usage
+type DiskStats struct {
+	Device            string
+	Mountpoint        string
+	Size              uint64
+	Used              uint64
+	Available         uint64
+	UsedPercent       float64
+	InodesUsedPercent float64
+}
+
+// DeviceGroupStats represents stats related to device group
+type DeviceGroupStats = device.DeviceGroupStats
+
+// DeviceStatsCollector is used to retrieve all the latest statistics for all devices.
+type DeviceStatsCollector func() []*DeviceGroupStats
+
+// NodeStatsCollector is an interface which is used for the purposes of mocking
+// the HostStatsCollector in the tests
+type NodeStatsCollector interface {
+	Collect() error
+	Stats() *HostStats
+}
+
+// HostStatsCollector collects host resource usage stats
+type HostStatsCollector struct {
+	numCores             int
+	statsCalculator      map[string]*HostCpuStatsCalculator
+	hostStats            *HostStats
+	hostStatsLock        sync.RWMutex
+	allocDir             string
+	deviceStatsCollector DeviceStatsCollector
+
+	// badParts is a set of partitions whose usage cannot be read; used to
+	// squelch logspam.
+	badParts map[string]struct{}
+
+	logger hclog.Logger
+}
+
+// NewHostStatsCollector returns a HostStatsCollector. The allocDir is passed in
+// so that we can present the disk related statistics for the mountpoint where
+// the allocation directory lives
+func NewHostStatsCollector(logger hclog.Logger, allocDir string, deviceStatsCollector DeviceStatsCollector) *HostStatsCollector {
+	logger = logger.Named("host_stats")
+	numCores := runtime.NumCPU()
+	statsCalculator := make(map[string]*HostCpuStatsCalculator)
+	collector := &HostStatsCollector{
+		statsCalculator:      statsCalculator,
+		numCores:             numCores,
+		logger:               logger,
+		allocDir:             allocDir,
+		badParts:             make(map[string]struct{}),
+		deviceStatsCollector: deviceStatsCollector,
+	}
+	return collector
+}
+
+// Collect collects stats related to resource usage of a host
+func (h *HostStatsCollector) Collect() error {
+	h.hostStatsLock.Lock()
+	defer h.hostStatsLock.Unlock()
+	return h.collectLocked()
+}
+
+// collectLocked collects stats related to resource usage of the host but should
+// be called with the lock held.
+func (h *HostStatsCollector) collectLocked() error {
+	hs := &HostStats{Timestamp: time.Now().UTC().UnixNano()}
+
+	// Determine up-time
+	uptime, err := host.Uptime()
+	if err != nil {
+		h.logger.Error("failed to collect upstime stats", "error", err)
+		uptime = 0
+	}
+	hs.Uptime = uptime
+
+	// Collect memory stats
+	mstats, err := h.collectMemoryStats()
+	if err != nil {
+		h.logger.Error("failed to collect memory stats", "error", err)
+		mstats = &MemoryStats{}
+	}
+	hs.Memory = mstats
+
+	// Collect cpu stats
+	cpus, ticks, err := h.collectCPUStats()
+	if err != nil {
+		h.logger.Error("failed to collect cpu stats", "error", err)
+		cpus = []*CPUStats{}
+		ticks = 0
+	}
+	hs.CPU = cpus
+	hs.CPUTicksConsumed = ticks
+
+	// Collect disk stats
+	diskStats, err := h.collectDiskStats()
+	if err != nil {
+		h.logger.Error("failed to collect disk stats", "error", err)
+		hs.DiskStats = []*DiskStats{}
+	}
+	hs.DiskStats = diskStats
+
+	// Getting the disk stats for the allocation directory
+	usage, err := disk.Usage(h.allocDir)
+	if err != nil {
+		h.logger.Error("failed to find disk usage of alloc", "alloc_dir", h.allocDir, "error", err)
+		hs.AllocDirStats = &DiskStats{}
+	} else {
+		hs.AllocDirStats = h.toDiskStats(usage, nil)
+	}
+	// Collect devices stats
+	deviceStats := h.collectDeviceGroupStats()
+	hs.DeviceStats = deviceStats
+
+	// Update the collected status object.
+	h.hostStats = hs
+
+	return nil
+}
+
+func (h *HostStatsCollector) collectMemoryStats() (*MemoryStats, error) {
+	memStats, err := mem.VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+	mem := &MemoryStats{
+		Total:     memStats.Total,
+		Available: memStats.Available,
+		Used:      memStats.Used,
+		Free:      memStats.Free,
+	}
+
+	return mem, nil
+}
+
+func (h *HostStatsCollector) collectDiskStats() ([]*DiskStats, error) {
+	partitions, err := disk.Partitions(false)
+	if err != nil {
+		return nil, err
+	}
+
+	var diskStats []*DiskStats
+	for _, partition := range partitions {
+		usage, err := disk.Usage(partition.Mountpoint)
+		if err != nil {
+			if _, ok := h.badParts[partition.Mountpoint]; ok {
+				// already known bad, don't log again
+				continue
+			}
+
+			h.badParts[partition.Mountpoint] = struct{}{}
+			h.logger.Warn("error fetching host disk usage stats", "error", err, "partition", partition.Mountpoint)
+			continue
+		}
+		delete(h.badParts, partition.Mountpoint)
+
+		ds := h.toDiskStats(usage, &partition)
+		diskStats = append(diskStats, ds)
+	}
+
+	return diskStats, nil
+}
+
+func (h *HostStatsCollector) collectDeviceGroupStats() []*DeviceGroupStats {
+	if h.deviceStatsCollector == nil {
+		return []*DeviceGroupStats{}
+	}
+
+	return h.deviceStatsCollector()
+}
+
+// Stats returns the host stats that has been collected
+func (h *HostStatsCollector) Stats() *HostStats {
+	h.hostStatsLock.RLock()
+	defer h.hostStatsLock.RUnlock()
+
+	if h.hostStats == nil {
+		if err := h.collectLocked(); err != nil {
+			h.logger.Warn("error fetching host resource usage stats", "error", err)
+		}
+	}
+
+	return h.hostStats
+}
+
+// toDiskStats merges UsageStat and PartitionStat to create a DiskStat
+func (h *HostStatsCollector) toDiskStats(usage *disk.UsageStat, partitionStat *disk.PartitionStat) *DiskStats {
+	ds := DiskStats{
+		Size:              usage.Total,
+		Used:              usage.Used,
+		Available:         usage.Free,
+		UsedPercent:       usage.UsedPercent,
+		InodesUsedPercent: usage.InodesUsedPercent,
+	}
+	if math.IsNaN(ds.UsedPercent) {
+		ds.UsedPercent = 0.0
+	}
+	if math.IsNaN(ds.InodesUsedPercent) {
+		ds.InodesUsedPercent = 0.0
+	}
+
+	if partitionStat != nil {
+		ds.Device = partitionStat.Device
+		ds.Mountpoint = partitionStat.Mountpoint
+	}
+
+	return &ds
+}
+
+// HostCpuStatsCalculator calculates cpu usage percentages
+type HostCpuStatsCalculator struct {
+	prevIdle   float64
+	prevUser   float64
+	prevSystem float64
+	prevBusy   float64
+	prevTotal  float64
+}
+
+// NewHostCpuStatsCalculator returns a HostCpuStatsCalculator
+func NewHostCpuStatsCalculator() *HostCpuStatsCalculator {
+	return &HostCpuStatsCalculator{}
+}
+
+// Calculate calculates the current cpu usage percentages
+func (h *HostCpuStatsCalculator) Calculate(times cpu.TimesStat) (idle float64, user float64, system float64, total float64) {
+	currentIdle := times.Idle
+	currentUser := times.User
+	currentSystem := times.System
+	currentTotal := times.Total() // this is Idle + currentBusy
+	currentBusy := times.User + times.System + times.Nice + times.Iowait + times.Irq +
+		times.Softirq + times.Steal + times.Guest + times.GuestNice
+
+	deltaTotal := currentTotal - h.prevTotal
+	idle = ((currentIdle - h.prevIdle) / deltaTotal) * 100
+	user = ((currentUser - h.prevUser) / deltaTotal) * 100
+	system = ((currentSystem - h.prevSystem) / deltaTotal) * 100
+	total = ((currentBusy - h.prevBusy) / deltaTotal) * 100
+
+	// Protect against any invalid values
+	if math.IsNaN(idle) || math.IsInf(idle, 0) || idle < 0.0 {
+		idle = 100.0
+	}
+	if math.IsNaN(user) || math.IsInf(user, 0) || user < 0.0 {
+		user = 0.0
+	}
+	if math.IsNaN(system) || math.IsInf(system, 0) || system < 0.0 {
+		system = 0.0
+	}
+	if math.IsNaN(total) || math.IsInf(total, 0) || total < 0 {
+		total = 0.0
+	}
+
+	h.prevIdle = currentIdle
+	h.prevUser = currentUser
+	h.prevSystem = currentSystem
+	h.prevTotal = currentTotal
+	h.prevBusy = currentBusy
+	return
+}

--- a/compat/nomad/client/stats/host_test.go
+++ b/compat/nomad/client/stats/host_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shoenig/test/must"
+)
+
+func TestHostCpuStatsCalculator_Nan(t *testing.T) {
+	times := cpu.TimesStat{
+		User:   0.0,
+		Idle:   100.0,
+		System: 0.0,
+	}
+
+	calculator := NewHostCpuStatsCalculator()
+	calculator.Calculate(times)
+	idle, user, system, total := calculator.Calculate(times)
+
+	must.Eq(t, 100.0, idle, must.Sprint("unexpected idle stats"))
+	must.Eq(t, 0.0, user, must.Sprint("unexpected user stats"))
+	must.Eq(t, 0.0, system, must.Sprint("unexpected system stats"))
+	must.Eq(t, 0.0, total, must.Sprint("unexpected total stats"))
+}
+
+func TestHostCpuStatsCalculator_DecreasedIOWait(t *testing.T) {
+	times := cpu.TimesStat{
+		CPU:    "cpu0",
+		User:   20000,
+		Nice:   100,
+		System: 9000,
+		Idle:   370000,
+		Iowait: 700,
+	}
+
+	calculator := NewHostCpuStatsCalculator()
+	calculator.Calculate(times)
+
+	times = cpu.TimesStat{
+		CPU:    "cpu0",
+		User:   20000,
+		Nice:   100,
+		System: 9000,
+		Idle:   380000,
+		Iowait: 600,
+	}
+
+	_, _, _, total := calculator.Calculate(times)
+	must.GreaterEq(t, 0.0, total, must.Sprint("total must never be negative"))
+}

--- a/compat/nomad/helper/stats/cpu.go
+++ b/compat/nomad/helper/stats/cpu.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stats
+
+import (
+	"runtime"
+	"time"
+)
+
+var (
+	cpuTotalTicks uint64
+)
+
+// CpuStats calculates cpu usage percentage
+type CpuStats struct {
+	prevCpuTime float64
+	prevTime    time.Time
+
+	totalCpus int
+}
+
+// NewCpuStats returns a cpu stats calculator
+func NewCpuStats() *CpuStats {
+	numCpus := runtime.NumCPU()
+	cpuStats := &CpuStats{
+		totalCpus: numCpus,
+	}
+	return cpuStats
+}
+
+// Percent calculates the cpu usage percentage based on the current cpu usage
+// and the previous cpu usage where usage is given as time in nanoseconds spend
+// in the cpu
+func (c *CpuStats) Percent(cpuTime float64) float64 {
+	now := time.Now()
+
+	if c.prevCpuTime == 0.0 {
+		// invoked first time
+		c.prevCpuTime = cpuTime
+		c.prevTime = now
+		return 0.0
+	}
+
+	timeDelta := now.Sub(c.prevTime).Nanoseconds()
+	ret := c.calculatePercent(c.prevCpuTime, cpuTime, timeDelta)
+	c.prevCpuTime = cpuTime
+	c.prevTime = now
+	return ret
+}
+
+// TicksConsumed calculates the total ticks consumes by the process across all
+// cpu cores
+func (c *CpuStats) TicksConsumed(percent float64) float64 {
+	return (percent / 100) * float64(CpuTotalTicks()) / float64(c.totalCpus)
+}
+
+func (c *CpuStats) calculatePercent(t1, t2 float64, timeDelta int64) float64 {
+	vDelta := t2 - t1
+	if timeDelta <= 0 || vDelta <= 0.0 {
+		return 0.0
+	}
+
+	overall_percent := (vDelta / float64(timeDelta)) * 100.0
+	return overall_percent
+}
+
+// Set the total ticks available across all cores.
+func SetCpuTotalTicks(newCpuTotalTicks uint64) {
+	cpuTotalTicks = newCpuTotalTicks
+}
+
+// CpuTotalTicks calculates the total MHz available across all cores.
+//
+// Where asymetric cores are correctly detected, the total ticks is the sum of
+// the performance across both core types.
+//
+// Where asymetric cores are not correctly detected (such as Intel 13th gen),
+// the total ticks available is over-estimated, as we assume all cores are P
+// cores.
+func CpuTotalTicks() uint64 {
+	return cpuTotalTicks
+}

--- a/compat/nomad/helper/stats/cpu_test.go
+++ b/compat/nomad/helper/stats/cpu_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/ci"
+)
+
+func TestCpuStatsPercent(t *testing.T) {
+	ci.Parallel(t)
+
+	cs := NewCpuStats()
+	cs.Percent(79.7)
+	time.Sleep(1 * time.Second)
+	percent := cs.Percent(80.69)
+	expectedPercent := 98.00
+	if percent < expectedPercent && percent > (expectedPercent+1.00) {
+		t.Fatalf("expected: %v, actual: %v", expectedPercent, percent)
+	}
+}

--- a/compat/nomad/helper/stats/runtime.go
+++ b/compat/nomad/helper/stats/runtime.go
@@ -1,0 +1,21 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stats
+
+import (
+	"runtime"
+	"strconv"
+)
+
+// RuntimeStats is used to return various runtime information
+func RuntimeStats() map[string]string {
+	return map[string]string{
+		"kernel.name": runtime.GOOS,
+		"arch":        runtime.GOARCH,
+		"version":     runtime.Version(),
+		"max_procs":   strconv.FormatInt(int64(runtime.GOMAXPROCS(0)), 10),
+		"goroutines":  strconv.FormatInt(int64(runtime.NumGoroutine()), 10),
+		"cpu_count":   strconv.FormatInt(int64(runtime.NumCPU()), 10),
+	}
+}

--- a/config.go
+++ b/config.go
@@ -146,6 +146,11 @@ type TaskLoggingConfig struct {
 	Options hclutils.MapStrStr `codec:"options"`
 }
 
+// Empty returns true if the logging configuration is not set.
+func (l *TaskLoggingConfig) Empty() bool {
+	return l.Driver == "" && len(l.Options) == 0
+}
+
 // VolumeConfig is the drivers volume specific configuration
 type VolumeConfig struct {
 	Enabled      bool   `codec:"enabled"`

--- a/config.go
+++ b/config.go
@@ -44,6 +44,16 @@ var (
 		),
 		// optional extra_labels to append to all tasks for observability. Globs supported
 		"extra_labels": hclspec.NewAttr("extra_labels", "list(string)", false),
+
+		// logging options
+		"logging": hclspec.NewDefault(hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{
+			"driver":  hclspec.NewAttr("driver", "string", false),
+			"options": hclspec.NewBlockAttrs("options", "string", false),
+		})), hclspec.NewLiteral(`{
+			driver = "nomad"
+			options = {}
+		}`)),
+
 		// the path to the podman api socket
 		"socket_path": hclspec.NewAttr("socket_path", "string", false),
 		// disable_log_collection indicates whether nomad should collect logs of podman
@@ -124,8 +134,8 @@ type GCConfig struct {
 
 // LoggingConfig is the tasks logging configuration
 type LoggingConfig struct {
-	Driver  string             `codec:"driver"`
-	Options hclutils.MapStrStr `codec:"options"`
+	Driver  string            `codec:"driver"`
+	Options map[string]string `codec:"options"`
 }
 
 // VolumeConfig is the drivers volume specific configuration
@@ -150,6 +160,7 @@ type PluginConfig struct {
 	ClientHttpTimeout    string           `codec:"client_http_timeout"`
 	ExtraLabels          []string         `codec:"extra_labels"`
 	DNSServers           []string         `codec:"dns_servers"`
+	Logging              LoggingConfig    `codec:"logging"`
 }
 
 // LogWarnings will emit logs about known problematic configurations

--- a/config.go
+++ b/config.go
@@ -132,10 +132,18 @@ type GCConfig struct {
 	Container bool `codec:"container"`
 }
 
-// LoggingConfig is the tasks logging configuration
+// LoggingConfig is the driver logging configuration
+// keep in sync with `TaskLoggingConfig`
 type LoggingConfig struct {
 	Driver  string            `codec:"driver"`
 	Options map[string]string `codec:"options"`
+}
+
+// LoggingConfig is the tasks logging configuration
+// keep in sync with `LoggingConfig`
+type TaskLoggingConfig struct {
+	Driver  string             `codec:"driver"`
+	Options hclutils.MapStrStr `codec:"options"`
 }
 
 // VolumeConfig is the drivers volume specific configuration
@@ -190,7 +198,7 @@ type TaskConfig struct {
 	Image             string             `codec:"image"`
 	ImagePullTimeout  string             `codec:"image_pull_timeout"`
 	InitPath          string             `codec:"init_path"`
-	Logging           LoggingConfig      `codec:"logging"`
+	Logging           TaskLoggingConfig  `codec:"logging"`
 	Labels            hclutils.MapStrStr `codec:"labels"`
 	MemoryReservation string             `codec:"memory_reservation"`
 	MemorySwap        string             `codec:"memory_swap"`

--- a/driver.go
+++ b/driver.go
@@ -513,6 +513,8 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	} else {
 		d.logger.Trace("no podman log driver provided, defaulting to plugin config")
 		switch d.config.Logging.Driver {
+		case "": // The default is nomad
+			fallthrough
 		case LOG_DRIVER_NOMAD:
 			if !d.config.DisableLogCollection {
 				createOpts.LogConfiguration.Driver = "k8s-file"

--- a/driver.go
+++ b/driver.go
@@ -497,9 +497,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	createOpts.ContainerBasicConfig.Labels = driverConfig.Labels
 
 	// Logging
-	if driverConfig.Logging.Driver != "" {
+	if !driverConfig.Logging.Empty() {
 		switch driverConfig.Logging.Driver {
-		case LOG_DRIVER_NOMAD:
+		case "", LOG_DRIVER_NOMAD:
 			if !d.config.DisableLogCollection {
 				createOpts.LogConfiguration.Driver = "k8s-file"
 				createOpts.ContainerBasicConfig.LogConfiguration.Path = cfg.StdoutPath
@@ -513,9 +513,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	} else {
 		d.logger.Trace("no podman log driver provided, defaulting to plugin config")
 		switch d.config.Logging.Driver {
-		case "": // The default is nomad
-			fallthrough
-		case LOG_DRIVER_NOMAD:
+		case "", LOG_DRIVER_NOMAD:
 			if !d.config.DisableLogCollection {
 				createOpts.LogConfiguration.Driver = "k8s-file"
 				createOpts.ContainerBasicConfig.LogConfiguration.Path = cfg.StdoutPath

--- a/lima.yaml
+++ b/lima.yaml
@@ -1,0 +1,71 @@
+# Please edit the following configuration for Lima instance "podman"
+# and an empty file will abort the edit.
+
+# Example to use Podman instead of containerd & nerdctl
+# $ limactl start ./podman.yaml
+# $ limactl shell podman podman run -it -v $HOME:$HOME --rm docker.io/library/alpine
+
+# To run `podman` on the host (assumes podman-remote is installed):
+# $ export CONTAINER_HOST=$(limactl list podman --format 'unix://{{.Dir}}/sock/podman.sock')
+# $ podman --remote ...
+
+# To run `docker` on the host (assumes docker-cli is installed):
+# $ export DOCKER_HOST=$(limactl list podman --format 'unix://{{.Dir}}/sock/podman.sock')
+# $ docker ...
+
+# This example requires Lima v0.8.0 or later
+images:
+  - location: "file:///Users/laoqui/Downloads/Fedora-IoT-38.20230414.1-20230414.1.aarch64.qcow2"
+    arch: "aarch64"
+
+mounts:
+- location: "~/go/src"
+  writable: true
+- location: "/tmp/lima"
+  writable: true
+containerd:
+  system: false
+  user: false
+provision:
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    curl -LO https://go.dev/dl/go1.19.5.linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64).tar.gz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.5.linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64).tar.gz
+    dnf groupinstall -y "Development Tools" "Development Libraries"
+- mode: user
+  script: |
+    #!/bin/bash
+    echo "export GOPATH=~/go" >> ~/.bashrc
+    echo "export PATH=~/go/bin:$PATH:/usr/local/go/bin" >> ~/.bashrc
+    #- mode: system
+    #  script: |
+    #    #!/bin/bash
+    #    set -eux -o pipefail
+    #    command -v podman >/dev/null 2>&1 && exit 0
+    #    dnf -y install podman
+    #- mode: user
+    #  script: |
+    #    #!/bin/bash
+    #    set -eux -o pipefail
+    #    systemctl --user enable --now podman.socket
+    #probes:
+    #- script: |
+    #    #!/bin/bash
+    #    set -eux -o pipefail
+    #    if ! timeout 30s bash -c "until command -v podman >/dev/null 2>&1; do sleep 3; done"; then
+    #      echo >&2 "podman is not installed yet"
+    #      exit 1
+    #    fi
+    #  hint: See "/var/log/cloud-init-output.log" in the guest
+    #portForwards:
+    #- guestSocket: "/run/user/{{.UID}}/podman/podman.sock"
+    #  hostSocket: "{{.Dir}}/sock/podman.sock"
+    #message: |
+    #  To run `podman` on the host (assumes podman-remote is installed), run the following commands:
+    #  ------
+    #  podman system connection add lima-{{.Name}} "unix://{{.Dir}}/sock/podman.sock"
+    #  podman system connection default lima-{{.Name}}
+    #  podman{{if eq .HostOS "linux"}} --remote{{end}} run quay.io/podman/hello
+    #  ------


### PR DESCRIPTION
This is similar to https://github.com/hashicorp/nomad/pull/10156/files and allows for a configuration like:

```
plugin "nomad-driver-podman" {
    config {
	extra_labels = ["job_name", "job_id", "task_group_name", "task_name", "namespace", "node_name", "node_id"]
	logging {
		driver = "journald"
		options = {
			tag = "{{index .Config.Labels \"com.hashicorp.nomad.alloc_id\" }}"
		}
	}
    }
}
```