### PR TITLE
feat: allow set global dns servers from client plugin config for contains

### DIFF
--- a/config.go
+++ b/config.go
@@ -149,7 +149,7 @@ type PluginConfig struct {
 	SocketPath           string           `codec:"socket_path"`
 	ClientHttpTimeout    string           `codec:"client_http_timeout"`
 	ExtraLabels          []string         `codec:"extra_labels"`
-	DNSServers           []string     `codec:"dns_servers"`
+	DNSServers           []string         `codec:"dns_servers"`
 }
 
 // LogWarnings will emit logs about known problematic configurations

--- a/config.go
+++ b/config.go
@@ -50,6 +50,7 @@ var (
 		// task containers.  If true, logs are not forwarded to nomad.
 		"disable_log_collection": hclspec.NewAttr("disable_log_collection", "bool", false),
 		"client_http_timeout":    hclspec.NewAttr("client_http_timeout", "string", false),
+		"dns_servers":            hclspec.NewAttr("dns_servers", "list(string)", false),
 	})
 
 	// taskConfigSpec is the hcl specification for the driver config section of
@@ -148,6 +149,7 @@ type PluginConfig struct {
 	SocketPath           string           `codec:"socket_path"`
 	ClientHttpTimeout    string           `codec:"client_http_timeout"`
 	ExtraLabels          []string         `codec:"extra_labels"`
+	DNSServers           []string     `codec:"dns_servers"`
 }
 
 // LogWarnings will emit logs about known problematic configurations

--- a/driver.go
+++ b/driver.go
@@ -609,12 +609,21 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		for _, strdns := range cfg.DNS.Servers {
 			ipdns := net.ParseIP(strdns)
 			if ipdns == nil {
-				return nil, nil, fmt.Errorf("Invalid dns server address")
+				return nil, nil, fmt.Errorf("Invalid dns server address, dns=%v", strdns)
 			}
 			createOpts.ContainerNetworkConfig.DNSServers = append(createOpts.ContainerNetworkConfig.DNSServers, ipdns)
 		}
 		createOpts.ContainerNetworkConfig.DNSSearch = append(createOpts.ContainerNetworkConfig.DNSSearch, cfg.DNS.Searches...)
 		createOpts.ContainerNetworkConfig.DNSOptions = append(createOpts.ContainerNetworkConfig.DNSOptions, cfg.DNS.Options...)
+	} else if len(d.config.DNSServers) > 0 {
+		// no task DNS specific, try load default DNS from plugin config
+		for _, strdns := range d.config.DNSServers {
+			ipdns := net.ParseIP(strdns)
+			if ipdns == nil {
+				return nil, nil, fmt.Errorf("Invalid dns server address from plugin config, dns=%v", strdns)
+			}
+			createOpts.ContainerNetworkConfig.DNSServers = append(createOpts.ContainerNetworkConfig.DNSServers, ipdns)
+		}
 	}
 	// Configure network
 	if cfg.NetworkIsolation != nil && cfg.NetworkIsolation.Path != "" {


### PR DESCRIPTION
so we can config dns for containers like:

```hcl
plugin "nomad-driver-podman" {
  config {
     dns_servers = ["192.168.8.100"]
  }
}
```