### PR TITLE
build: ensure podman service is active

### DIFF
--- a/.github/machinesetup.sh
+++ b/.github/machinesetup.sh
@@ -7,15 +7,11 @@ set -euo pipefail
 
 echo "====== Install tools from apt"
 apt-get update
-apt-get install -y ca-certificates podman curl build-essential
+apt-get install -qq -y ca-certificates podman curl build-essential
 
 echo "====== Install catatonit"
-curl -v -L -o /usr/local/bin/catatonit https://github.com/openSUSE/catatonit/releases/download/v0.1.7/catatonit.x86_64
+curl -s -S -L -o /usr/local/bin/catatonit https://github.com/openSUSE/catatonit/releases/download/v0.1.7/catatonit.x86_64
 chmod +x /usr/local/bin/catatonit
-
-echo "====== Podman info"
-podman version
-podman info
 
 echo "====== Setup archives"
 podman pull alpine:3
@@ -30,3 +26,10 @@ unqualified-search-registries = ["docker.io", "quay.io"]
 location = "localhost:5000"
 insecure = true
 EOF
+
+echo "====== Podman info"
+systemctl start podman
+systemctl status podman
+podman version
+podman info
+


### PR DESCRIPTION
It seems the `podman` package for ubuntu now deactivates `podman` after install which means the socket activation does nothing. This explains why the `Run CI Tests` workflow has been completely broken recently. 

from a debug branch https://github.com/hashicorp/nomad-driver-podman/actions/runs/7183730982/job/19563150699#step:6:34

```
 ○ podman.service - Podman API Service
     Loaded: loaded (/lib/systemd/system/podman.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Tue 2023-12-12 15:35:06 UTC; 1min 20s ago
TriggeredBy: ○ podman.socket
       Docs: man:podman-system-service(1)
    Process: 2779 ExecStart=/usr/bin/podman $LOGGING system service (code=exited, status=0/SUCCESS)
   Main PID: 2779 (code=exited, status=0/SUCCESS)
        CPU: 86ms
```