### PR TITLE
Fix podman 5.0 unmarshall error.

### DIFF
--- a/api/structs.go
+++ b/api/structs.go
@@ -581,7 +581,8 @@ type InspectContainerConfig struct {
 	// Container working directory
 	WorkingDir string `json:"WorkingDir"`
 	// Container entrypoint
-	Entrypoint string `json:"Entrypoint"`
+	// Podman 5.0 changed this to []string, ignoring.
+	// Entrypoint []string `json:"Entrypoint"`
 	// On-build arguments - presently unused. More of Buildah's domain.
 	OnBuild *string `json:"OnBuild"`
 	// Container labels
@@ -589,7 +590,8 @@ type InspectContainerConfig struct {
 	// Container annotations
 	Annotations map[string]string `json:"Annotations"`
 	// Container stop signal
-	StopSignal uint `json:"StopSignal"`
+	// Podman 5.0 changed this to string, ignoring.
+	// StopSignal string `json:"StopSignal"`
 	// Configured healthcheck for the container
 	// Healthcheck *manifest.Schema2HealthConfig `json:"Healthcheck,omitempty"`
 	// CreateCommand is the full command plus arguments of the process the


### PR DESCRIPTION
Podman 5.0 introduces some inspect API type changes: [commit](https://github.com/containers/podman/commit/de845a5b427b82004130f27fec5c27f397722c27), breaking the unmarshal code. Since we don't use the fields, we just delete them. See Issue #331. 

Testing:
- Manully Verified that this works against podman 4.9.3 and 5.0 (nomad 1.7.6). [lightly edited transcript](https://pastebin.com/m8g74y3J)

Note: 
- libpod has just implemented a compatible unmarshal API [here](https://github.com/containers/podman/commit/585af039d7a37580065076648550802d674dd901).