### PR TITLE
build: create linux package during CRT build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: ["arm64", "amd64"]
+        goarch: ["arm", "arm64", "amd64"]
       fail-fast: false # recommended during development
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: build
 
-on:
-  push:
-  workflow_dispatch:
-  workflow_call:
+on: [workflow_dispatch, push]
 
 env:
   PKG_NAME: "nomad-driver-podman"
@@ -11,37 +8,37 @@ env:
 jobs:
   get-go-version:
     name: "Determine Go toolchain version"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Determine Go version
         id: get-go-version
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "::set-output name=go-version::$(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
 
   get-product-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: get product version
         id: get-product-version
         run: |
           make version
-          echo "::set-output name=product-version::$(make version)"
+          echo "product-version=$(make version)" >> "$GITHUB_OUTPUT"
 
   generate-metadata-file:
     needs: get-product-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: "Checkout directory"
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
@@ -49,8 +46,7 @@ jobs:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        if: ${{ !env.ACT }}
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -59,31 +55,26 @@ jobs:
     needs:
       - get-go-version
       - get-product-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        goos: ["linux"]
-        goarch: ["amd64", "arm64", "arm"]
-      fail-fast: true
-
+        goos: [linux]
+        goarch: ["arm64", "amd64"]
+      fail-fast: false # recommended during development
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Setup go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-        with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: hashicorp/setup-golang@v3
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          make dist/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv \
-            pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip \
+            dist/${{ matrix.goos }}_${{ matrix.goarch }}.zip \
             ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         if: ${{ !env.ACT }}
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,33 @@ jobs:
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+      - name: Package
+        if: ${{ matrix.goos == 'linux' }}
+        uses: hashicorp/actions-packaging-linux@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: "nomad-driver-podman is a HashiCorp Nomad task driver for Linux."
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.set-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/nomad-driver-podman"
+          license: "MPL-2.0"
+          binary: "dist/${{ matrix.goos }}_${{ matrix.goarch }}/${{ env.PKG_NAME }}"
+          postinstall: ".release/linux/postinst"
+          postremove: ".release/linux/postrm"
+
+      - name: Set Package Names
+        if: ${{ matrix.goos == 'linux' }}
+        run: |
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> "$GITHUB_ENV"
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> "$GITHUB_ENV"
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ env.RPM_PACKAGE }}
+          path: out/${{ env.RPM_PACKAGE }}
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ env.DEB_PACKAGE }}
+          path: out/${{ env.DEB_PACKAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           name: ${{ github.event.repository.name }}
           description: "nomad-driver-podman is a HashiCorp Nomad task driver for Linux."
           arch: ${{ matrix.goarch }}
-          version: ${{ needs.set-product-version.outputs.product-version }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://github.com/hashicorp/nomad-driver-podman"
           license: "MPL-2.0"

--- a/.release/linux/postinst
+++ b/.release/linux/postinst
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mkdir -p /opt/nomad/plugins
+ln -s /usr/bin/nomad-driver-podman /opt/nomad/plugins/nomad-driver-podman

--- a/.release/linux/postrm
+++ b/.release/linux/postrm
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-rm /opt/nomad/plugins/nomad-driver-podman
+rm -f /opt/nomad/plugins/nomad-driver-podman

--- a/.release/linux/postrm
+++ b/.release/linux/postrm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm /opt/nomad/plugins/nomad-driver-podman

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -111,8 +111,3 @@ dist/%.zip: dist/%/nomad-driver-exec2
 	@echo "==> RELEASE PACKAGING of $@ ..."
 	@cp LICENSE $(dir $<)LICENSE.txt
 	zip -j $@ $(dir $<)*
-
-# CRT version generation
-.PHONY: version
-version:
-	@$(CURDIR)/version/generate.sh version/version.go version/version.go

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -99,15 +99,15 @@ else
 endif
 
 # CRT release compilation
-dist/%/nomad-driver-exec2: GO_OUT ?= $@
-dist/%/nomad-driver-exec2:
+dist/%/nomad-driver-podman: GO_OUT ?= $@
+dist/%/nomad-driver-podman:
 	@echo "==> RELEASE BUILD of $@ ..."
 	GOOS=linux GOARCH=$(lastword $(subst _, ,$*)) \
 	go build -trimpath -o $(GO_OUT)
 
 # CRT release packaging (zip only)
-.PRECIOUS: dist/%/nomad-driver-exec2
-dist/%.zip: dist/%/nomad-driver-exec2
+.PRECIOUS: dist/%/nomad-driver-podman
+dist/%.zip: dist/%/nomad-driver-podman
 	@echo "==> RELEASE PACKAGING of $@ ..."
 	@cp LICENSE $(dir $<)LICENSE.txt
 	zip -j $@ $(dir $<)*

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -97,3 +97,22 @@ ifneq (,$(wildcard version/version_ent.go))
 else
 	@$(CURDIR)/scripts/version.sh version/version.go version/version.go
 endif
+
+# CRT release compilation
+dist/%/nomad-driver-exec2: GO_OUT ?= $@
+dist/%/nomad-driver-exec2:
+	@echo "==> RELEASE BUILD of $@ ..."
+	GOOS=linux GOARCH=$(lastword $(subst _, ,$*)) \
+	go build -trimpath -o $(GO_OUT)
+
+# CRT release packaging (zip only)
+.PRECIOUS: dist/%/nomad-driver-exec2
+dist/%.zip: dist/%/nomad-driver-exec2
+	@echo "==> RELEASE PACKAGING of $@ ..."
+	@cp LICENSE $(dir $<)LICENSE.txt
+	zip -j $@ $(dir $<)*
+
+# CRT version generation
+.PHONY: version
+version:
+	@$(CURDIR)/version/generate.sh version/version.go version/version.go


### PR DESCRIPTION
This PR creates .deb and .rpm Linux packages of the nomad-driver-podman
task driver. Given limitations of our packaging system the driver gets
installed in /usr/bin/ but then gets linked to /opt/nomad/plugins/ during
the install steps (and likewise removed during uninstall). This way the
plugin Just Works with the default configuration of Nomad.

Closes https://github.com/hashicorp/nomad-driver-podman/issues/344