### PR TITLE
build: remove 32-bit builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: ["arm", "arm64", "amd64"]
+        goarch: ["arm64", "amd64"]
       fail-fast: false # recommended during development
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:


### PR DESCRIPTION
We no longer intend to release 32-bit builds for any platform for Nomad ecosystem projects.

Ref: https://github.com/hashicorp/nomad/pull/23189
Ref: https://github.com/hashicorp/nomad-enterprise/issues/1053