### PR TITLE
Fix empty log lines in journald (fixes #339)

### DIFF
--- a/api/container_logs.go
+++ b/api/container_logs.go
@@ -48,13 +48,10 @@ func (c *API) ContainerLogs(ctx context.Context, name string, since time.Time, s
 		switch fd {
 		case 0:
 			_, _ = stdout.Write(frame)
-			_, _ = stdout.Write([]byte("\n"))
 		case 1:
 			_, _ = stdout.Write(frame)
-			_, _ = stdout.Write([]byte("\n"))
 		case 2:
 			_, _ = stderr.Write(frame)
-			_, _ = stderr.Write([]byte("\n"))
 		case 3:
 			return fmt.Errorf("Error from log service: %s", string(frame))
 		default:


### PR DESCRIPTION
**Problem**: When using the journald logging, empty loglines are added by nomad. (resolves #339 )

**before**:
![empty_loglines](https://github.com/user-attachments/assets/98cdadbf-97fb-4ef8-a135-8aa0d750766b)

**after**:
![empty_loglines_fixed](https://github.com/user-attachments/assets/dedd535d-0c07-4aa5-9a2b-b99945778f6d)
