### PR TITLE
(Regression) Tests and bugfixes for multiple socket implementation

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -222,7 +222,6 @@ func (d *Driver) makePodmanClients(sockets []PluginSocketConfig, timeout time.Du
 		if sock.Name == "" {
 			sock.Name = "default"
 		}
-		sock.Name = sock.Name
 		if sock.Name == "default" && !foundDefaultPodman {
 			foundDefaultPodman = true
 			podmanClient = d.newPodmanClient(timeout, sock.SocketPath, true)

--- a/driver.go
+++ b/driver.go
@@ -269,7 +269,7 @@ func (d *Driver) getPodmanClient(clientName string) (*api.API, error) {
 	if ok {
 		return p, nil
 	}
-	return nil, fmt.Errorf("podman client with name '%s' was not found, check your podman driver config", clientName)
+	return nil, fmt.Errorf("podman client with name %q was not found, check your podman driver config", clientName)
 }
 
 // newPodmanClient returns Podman client configured with the provided timeout.
@@ -332,7 +332,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 		// Ping podman api
 		apiVersion, err := podmanClient.Ping(d.ctx)
 		attrPrefix := fmt.Sprintf("driver.podman.%s", cleanUpSocketName(name))
-		if name == "default" || podmanClient.IsDefaultClient() {
+		if podmanClient.IsDefaultClient() {
 			attrPrefix = "driver.podman"
 		}
 
@@ -535,7 +535,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		var err error
 		podmanClient, err = d.getPodmanClient(podmanTaskSocketName)
 		if err != nil {
-			return nil, nil, fmt.Errorf("podman client with name '%s' not found, check your podman driver config", podmanTaskSocketName)
+			return nil, nil, fmt.Errorf("podman client with name %q not found, check your podman driver config", podmanTaskSocketName)
 		}
 	}
 	rootless := podmanClient.IsRootless()

--- a/driver_test.go
+++ b/driver_test.go
@@ -2519,6 +2519,7 @@ func Test_namedSocketBecomesDefaultSocket(t *testing.T) {
 	must.True(t, ok)
 	must.Eq(t, "podmanSock", originalName)
 	isDefaultAttr, ok := fingerprint.Attributes["driver.podman.defaultPodman"].GetBool()
+	must.True(t, ok)
 	must.True(t, isDefaultAttr)
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -2511,7 +2511,7 @@ func Test_namedSocketBecomesDefaultSocket(t *testing.T) {
 	api, err := getPodmanDriver(t, d).getPodmanClient("podmanSock")
 	must.NoError(t, err)
 	must.True(t, api.IsDefaultClient())
-	
+
 	fingerprint := getPodmanDriver(t, d).buildFingerprint()
 	must.MapContainsKey(t, fingerprint.Attributes, "driver.podman.socketName")
 


### PR DESCRIPTION
This PR contains some fixes in the podman driver behaviour when there are multiple sockets in use. Additionally, I've written regression tests that test the behaviour of having multiple sockets.

Fixes:
* If there was one socket with a name different from "default", the attributes would not get prefixed with `driver.podman.attrName` but with `driver.podman.<name of socket>.attrName`. Since this would break existing nomad scheduling, now if a socket is the default socket (`isDefaultClient()` returns true), attributes are written with the `driver.podman.attrName` syntax. Also added `driver.podman.[<name of socket>.]socketName attribute so it's still possible to find the name when it's the default (+ makes it easier if you're using attribute filtering to verify podman has the low-priv socket you want)
![fix1](https://github.com/user-attachments/assets/2fbf2ef9-dfab-4ed2-8d74-ef30701278be)
* I implemented a clean string function `cleanUpSocketName()` for the purpose of having nice attribute names but by cleaning it before using it as a key in podmanClient map, it made it so that it was no longer "found" by other operations using the map and not cleaning the socket name. Since the internal representation of the socket name as a key in a map is safe, I removed the cleanup function and only apply it where I wanted it: in the attributes.

`driver_test.go` contains the Tests that validate this behaviour.