### PR TITLE
Fix: Honor Default Logging Driver Configuration

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -898,7 +898,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		exitResult:            &drivers.ExitResult{},
 		startedAt:             time.Now(),
 		logger:                d.logger.Named(fmt.Sprintf("podman.%s", podmanTaskSocketName)),
-		logStreamer:           podmanTaskConfig.Logging.Driver == LOG_DRIVER_JOURNALD,
+		logStreamer:           createOpts.LogConfiguration.Driver == LOG_DRIVER_JOURNALD,
 		logPointer:            time.Now(),
 		collectionInterval:    time.Second,
 		totalCPUStats:         cpustats.New(d.compute),


### PR DESCRIPTION
### Fix: Honor Default Logging Driver Configuration

**Issue:**
When journald is specified as a logging driver, logs should be streamed back to nomad when disable_log_collection is false.
Currently this only works if the task-specific logging configuration is set to journald. If only the global driver configuration is set to log to journald, logs are not streamed back to nomad.
This results in empty task logs in the Nomad UI.

**Fix:**
Updated the logic to use the final resolved logging driver (`createOpts.LogConfiguration.Driver`) instead of the task-specific configuration (`podmanTaskConfig.Logging.Driver`). This ensures:
1. Default logging configurations are honored.
2. Logs are correctly collected and displayed in the Nomad UI.

**Impact:**
- Prevents empty logs in the Nomad UI and ensures consistent log collection.
- Logs are correctly streamed back to nomad if the global driver logging config is set to journald.

**Testing:**
- Verified logs are correctly written and displayed when no task-specific configuration is provided.
- Confirmed `logStreamer` aligns with the final logging driver.