### PR TITLE
Fix: use `volumes` instead of `v` for libpod API to delete container

### DIFF
--- a/api/container_delete.go
+++ b/api/container_delete.go
@@ -13,7 +13,7 @@ import (
 // It takes the name or ID of a container.
 func (c *API) ContainerDelete(ctx context.Context, name string, force bool, deleteVolumes bool) error {
 
-	res, err := c.Delete(ctx, fmt.Sprintf("/v1.0.0/libpod/containers/%s?force=%t&v=%t", name, force, deleteVolumes))
+	res, err := c.Delete(ctx, fmt.Sprintf("/v1.0.0/libpod/containers/%s?force=%t&volumes=%t", name, force, deleteVolumes))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Based on the discussion from https://github.com/containers/podman/discussions/25657, the correct parameter for volume is `volumes`.

Using `v`, will not remove the anonymous volumes created. 