### PR TITLE
Add oom_score_adj config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,16 @@ config {
 }
 ```
 
+* **oom_score_adj** - Set the [--oom-score-adj](https://docs.podman.io/en/latest/markdown/podman-run.1.html#oom-score-adj-num) for the container
+
+Tune the host’s OOM preferences for containers (accepts values from -1000 to 1000).
+
+```hcl
+config {
+  oom_score_adj = "-1000"
+}
+```
+
 * **socket** - (Optional) The name of the socket as defined in the socket block in the client agent's plugin configuration. Defaults to the socket named "default".
 
 ```hcl

--- a/config.go
+++ b/config.go
@@ -112,6 +112,7 @@ var (
 		"memory_swap":        hclspec.NewAttr("memory_swap", "string", false),
 		"memory_swappiness":  hclspec.NewAttr("memory_swappiness", "number", false),
 		"network_mode":       hclspec.NewAttr("network_mode", "string", false),
+		"oom_score_adj":      hclspec.NewAttr("oom_score_adj", "number", false),
 		"extra_hosts":        hclspec.NewAttr("extra_hosts", "list(string)", false),
 		"pids_limit":         hclspec.NewAttr("pids_limit", "number", false),
 		"port_map":           hclspec.NewAttr("port_map", "list(map(number))", false),
@@ -229,6 +230,7 @@ type TaskConfig struct {
 	MemoryReservation string             `codec:"memory_reservation"`
 	MemorySwap        string             `codec:"memory_swap"`
 	NetworkMode       string             `codec:"network_mode"`
+	OOMScoreAdj       int16              `codec:"oom_score_adj"`
 	ExtraHosts        []string           `codec:"extra_hosts"`
 	CPUCFSPeriod      uint64             `codec:"cpu_cfs_period"`
 	MemorySwappiness  int64              `codec:"memory_swappiness"`

--- a/config_test.go
+++ b/config_test.go
@@ -152,3 +152,19 @@ func TestConfig_PodmanSocketDefaultIfNotGiven(t *testing.T) {
 	parser.ParseHCL(t, validHCL, &tc)
 	must.Eq(t, "default", tc.Socket)
 }
+
+func TestConfig_PodmanOOMScoreAdj(t *testing.T) {
+	ci.Parallel(t)
+
+	parser := hclutils.NewConfigParser(taskConfigSpec)
+	validHCL := `
+	config {
+		image = "docker://redis"
+		oom_score_adj = -1000
+	}
+	`
+
+	var tc *TaskConfig
+	parser.ParseHCL(t, validHCL, &tc)
+	must.Eq(t, "default", tc.Socket)
+}

--- a/driver.go
+++ b/driver.go
@@ -716,6 +716,10 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		swappiness := uint64(podmanTaskConfig.MemorySwappiness)
 		createOpts.ContainerResourceConfig.ResourceLimits.Memory.Swappiness = &swappiness
 	}
+	// OOM Score Adj config options
+	oomScoreAdj := int(podmanTaskConfig.OOMScoreAdj)
+	createOpts.ContainerResourceConfig.OOMScoreAdj = &oomScoreAdj
+
 	// FIXME: can fail for nonRoot due to missing cpu limit delegation permissions,
 	//        see https://github.com/containers/podman/blob/master/troubleshooting.md
 	if !rootless {


### PR DESCRIPTION
This PR introduces the oom-score-adj configuration option to the current driver implementation. The addition of this option provides users with the ability to adjust the OOM (Out Of Memory) scope for containers managed by Podman, allowing for finer control over resource usage and OOM killer behavior.
Motivation

In scenarios where a resource-heavy application is running within a container, it is often necessary to have more control over how the system’s OOM killer prioritizes processes. The oom-score-adj configuration allows users to fine-tune this behavior, either by preventing the OOM killer from targeting critical processes or by adjusting the OOM score to better suit specific workload requirements.

This feature is particularly useful when:
 - Running a resource-intensive application where controlling memory usage and prioritizing processes is crucial.
 - Tuning the OOM score to align with specific application needs, ensuring that critical services are not prematurely killed by the OOM killer.

Changes
 - Added oom-scope-adj option to the task configuration.
 - Provided a mechanism for users to control the OOM score adjustment for containers.