### PR TITLE
adds tests for tmpfs and updates changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ IMPROVEMENTS:
 
 * build: Update Nomad verison to 1.10.0 [GH-431](https://github.com/hashicorp/nomad-driver-podman/pull/431)
 * build: Updated to Go 1.24.2 [[GH-430](https://github.com/hashicorp/nomad-driver-podman/pull/430)]
+* config: Adds support for oom_score_adj [GH-425](https://github.com/hashicorp/nomad-driver-podman)
 
 BUG FIXES:
 
-* fingerprint: check for nil pointers in SystemInfo client response. [[GH-412](https://github.com/hashicorp/nomad-driver-podman/issues/412)]
+* fingerprint: Check for nil pointers in SystemInfo client response. [[GH-412](https://github.com/hashicorp/nomad-driver-podman/issues/412)]
+* recovery: Fixes driver failing to recover task [GH-433](https://github.com/hashicorp/nomad-driver-podman/pull/433)
+* runtime: Fixes parsing options when creating a tmpfs mount [GH-439](https://github.com/hashicorp/nomad-driver-podman/pull/439)
+* logging: Fixes bug where driver did not honor default logging configuration
 
 ## 0.6.2 (December 16, 2024)
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -1459,7 +1459,7 @@ func TestPodmanDriver_Tmpfs(t *testing.T) {
 	})
 	taskCfg.Tmpfs = []string{
 		"/tmpdata1",
-		"/tmpdata2",
+		"/tmpdata2:rshared,noexec",
 	}
 
 	task := &drivers.TaskConfig{
@@ -1499,7 +1499,7 @@ func TestPodmanDriver_Tmpfs(t *testing.T) {
 
 	expectedFilesystem := map[string]string{
 		"/tmpdata1": "rw,rprivate,nosuid,nodev,tmpcopyup",
-		"/tmpdata2": "rw,rprivate,nosuid,nodev,tmpcopyup",
+		"/tmpdata2": "rshared,noexec,rw,nosuid,nodev,tmpcopyup",
 	}
 	must.MapEq(t, expectedFilesystem, inspectData.HostConfig.Tmpfs)
 


### PR DESCRIPTION
Updates an existing test to test changes made in [GH-439](https://github.com/hashicorp/nomad-driver-podman/pull/439), and adds missing changelog items.