### PR TITLE
Static IP, IPv6 and MAC addresses with Podman >=4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 IMPROVEMENTS:
 
+* api: Added support for ipv6_address, ipv4_address, static_ips, and static_mac options to networking configuration [[GH-359](https://github.com/hashicorp/nomad-driver-podman/pull/359)]
+* api: Address a backwards incompatible change in Podman 4.0 for secondary IP addresses [[GH-443](https://github.com/hashicorp/nomad-driver-podman/pull/443)]
 * build: Update Nomad verison to 1.10.0 [[GH-431](https://github.com/hashicorp/nomad-driver-podman/pull/431)]
 * build: Updated to Go 1.24.2 [[GH-430](https://github.com/hashicorp/nomad-driver-podman/pull/430)]
 * config: Adds support for oom_score_adj [[GH-425](https://github.com/hashicorp/nomad-driver-podman)]
-* api: Address a backwards incompatible change in Podman 4.0 for secondary IP addresses [[GH-443](https://github.com/hashicorp/nomad-driver-podman/pull/443)]
 
 BUG FIXES:
 

--- a/api/structs.go
+++ b/api/structs.go
@@ -338,6 +338,19 @@ type ContainerCgroupConfig struct {
 	CgroupParent string `json:"cgroup_parent,omitempty"`
 }
 
+// PerNetworkOptions allows you to set options per network the container is
+// attached to.
+type PerNetworkOptions struct {
+	// Aliases contains a list of names which the dns server should resolve to this container. Should only be set when DNSEnabled is true on the Network. If aliases are set but there is no dns support for this network the network interface implementation should ignore this and NOT error. Optional.
+	Aliases []string `json:"aliases,omitempty"`
+	// InterfaceName for this container. Required in the backend. Optional in the frontend. Will be filled with ethX (where X is a integer) when empty.
+	InterfaceName string `json:"interface_name,omitempty"`
+	// StaticIPs for this container. Optional.
+	StaticIPs []*net.IP `json:"static_ips,omitempty"`
+	// StaticMac for this container. Optional.
+	StaticMac *net.HardwareAddr `json:"static_mac,omitempty"`
+}
+
 // ContainerNetworkConfig contains information on a container's network
 // configuration.
 type ContainerNetworkConfig struct {
@@ -419,6 +432,13 @@ type ContainerNetworkConfig struct {
 	// Podman, and instead sourced from the image.
 	// Conflicts with HostAdd.
 	UseImageHosts bool `json:"use_image_hosts,omitempty"`
+	// Map of networks names or ids that the container should join. You can
+	// request additional settings for each network, you can set network
+	// aliases, static ips, static mac address and the network interface name
+	// for this container on the specific network. If the map is empty and the
+	// bridge network mode is set the container will be joined to the default
+	// network.
+	Networks map[string]PerNetworkOptions `json:"networks,omitempty"`
 }
 
 // ContainerResourceConfig contains information on container resource limits.

--- a/api/structs.go
+++ b/api/structs.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containers/common/libnetwork/types"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -348,7 +349,7 @@ type PerNetworkOptions struct {
 	// StaticIPs for this container. Optional.
 	StaticIPs []*net.IP `json:"static_ips,omitempty"`
 	// StaticMac for this container. Optional.
-	StaticMac *net.HardwareAddr `json:"static_mac,omitempty"`
+	StaticMac types.HardwareAddr `json:"static_mac,omitempty"`
 }
 
 // ContainerNetworkConfig contains information on a container's network
@@ -438,7 +439,7 @@ type ContainerNetworkConfig struct {
 	// for this container on the specific network. If the map is empty and the
 	// bridge network mode is set the container will be joined to the default
 	// network.
-	Networks map[string]PerNetworkOptions `json:"networks,omitempty"`
+	Networks map[string]PerNetworkOptions `json:"newNetworks,omitempty"`
 }
 
 // ContainerResourceConfig contains information on container resource limits.

--- a/config.go
+++ b/config.go
@@ -101,9 +101,13 @@ var (
 			hclspec.NewAttr("image_pull_timeout", "string", false),
 			hclspec.NewLiteral(`"5m"`),
 		),
-		"init":      hclspec.NewAttr("init", "bool", false),
-		"init_path": hclspec.NewAttr("init_path", "string", false),
-		"labels":    hclspec.NewAttr("labels", "list(map(string))", false),
+		"init":         hclspec.NewAttr("init", "bool", false),
+		"init_path":    hclspec.NewAttr("init_path", "string", false),
+		"ipv4_address": hclspec.NewAttr("ipv4_address", "string", false),
+		"ipv6_address": hclspec.NewAttr("ipv6_address", "string", false),
+		"static_ips":   hclspec.NewAttr("static_ips", "list(string)", false),
+		"static_macs":  hclspec.NewAttr("static_macs", "list(string)", false),
+		"labels":       hclspec.NewAttr("labels", "list(map(string))", false),
 		"logging": hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"driver":  hclspec.NewAttr("driver", "string", false),
 			"options": hclspec.NewAttr("options", "list(map(string))", false),
@@ -224,6 +228,10 @@ type TaskConfig struct {
 	Hostname          string             `codec:"hostname"`
 	Image             string             `codec:"image"`
 	ImagePullTimeout  string             `codec:"image_pull_timeout"`
+	IPv4Address       string             `codec:"ipv4_address"`
+	IPv6Address       string             `codec:"ipv6_address"`
+	StaticIPs         []string           `codec:"static_ips"`
+	StaticMAC         string             `codec:"static_mac"`
 	InitPath          string             `codec:"init_path"`
 	Logging           TaskLoggingConfig  `codec:"logging"`
 	Labels            hclutils.MapStrStr `codec:"labels"`

--- a/driver.go
+++ b/driver.go
@@ -826,29 +826,49 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	// list of static addresses too. Add all three options to the API call for
 	// the default network
 	if podmanTaskConfig.StaticMAC != "" || podmanTaskConfig.IPv4Address != "" || podmanTaskConfig.IPv6Address != "" || len(podmanTaskConfig.StaticIPs) > 0 {
-		apiVersion, _ := podmanClient.Ping(d.ctx)
+		apiVersion := podmanClient.GetAPIVersion()
 		versionValue, _ := version2.NewVersion(apiVersion)
 		versionCheck, _ := version2.NewConstraint(">=4.0.0")
+
+		var (
+			staticIPv4 *net.IP
+			staticIPv6 *net.IP
+			staticMac  net.HardwareAddr
+		)
+
+		if podmanTaskConfig.IPv4Address != "" {
+			parsedIP := net.ParseIP(podmanTaskConfig.IPv4Address)
+			if parsedIP != nil {
+				staticIPv4 = &parsedIP
+			}
+		}
+
+		if podmanTaskConfig.IPv6Address != "" {
+			parsedIPv6 := net.ParseIP(podmanTaskConfig.IPv6Address)
+			if parsedIPv6 != nil {
+				staticIPv6 = &parsedIPv6
+			}
+		}
+		if podmanTaskConfig.StaticMAC != "" {
+			parsedMAC, macErr := net.ParseMAC(podmanTaskConfig.StaticMAC)
+			if macErr == nil && parsedMAC != nil {
+				staticMac = parsedMAC
+			}
+		}
 
 		if versionCheck.Check(versionValue) {
 			// Podman API v4 uses PerNetworkOptions. For now, we'll just use the
 			// default network.
+			netOpts := api.PerNetworkOptions{StaticIPs: []*net.IP{}}
 
-			netOpts := api.PerNetworkOptions{}
-			netOpts.StaticIPs = []*net.IP{}
-
-			if podmanTaskConfig.IPv4Address != "" {
-				parsedIP := net.ParseIP(podmanTaskConfig.IPv4Address)
-				if parsedIP != nil {
-					netOpts.StaticIPs = append(netOpts.StaticIPs, &parsedIP)
-				}
+			if staticIPv4 != nil {
+				netOpts.StaticIPs = append(netOpts.StaticIPs, staticIPv4)
 			}
-
-			if podmanTaskConfig.IPv6Address != "" {
-				parsedIPv6 := net.ParseIP(podmanTaskConfig.IPv6Address)
-				if parsedIPv6 != nil {
-					netOpts.StaticIPs = append(netOpts.StaticIPs, &parsedIPv6)
-				}
+			if staticIPv6 != nil {
+				netOpts.StaticIPs = append(netOpts.StaticIPs, staticIPv6)
+			}
+			if staticMac != nil {
+				netOpts.StaticMac = nettypes.HardwareAddr(staticMac)
 			}
 
 			if len(podmanTaskConfig.StaticIPs) > 0 {
@@ -859,39 +879,17 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 					}
 				}
 			}
-
-			// Process Static MAC configuration
-			if podmanTaskConfig.StaticMAC != "" {
-				parsedMAC, macErr := net.ParseMAC(podmanTaskConfig.StaticMAC)
-				if macErr == nil && parsedMAC != nil {
-					netOpts.StaticMac = nettypes.HardwareAddr(parsedMAC)
-				}
-			}
-
 			createOpts.Networks = map[string]api.PerNetworkOptions{"default": netOpts}
 		} else {
 			// Before version 4, there were StaticIP, StaticIPv6 and StaticMAC properties
-
-			if podmanTaskConfig.IPv4Address != "" {
-				parsedIP := net.ParseIP(podmanTaskConfig.IPv4Address)
-				if parsedIP != nil {
-					createOpts.ContainerNetworkConfig.StaticIP = &parsedIP
-				}
+			if staticIPv4 != nil {
+				createOpts.ContainerNetworkConfig.StaticIP = staticIPv4
 			}
-
-			if podmanTaskConfig.IPv6Address != "" {
-				parsedIPv6 := net.ParseIP(podmanTaskConfig.IPv6Address)
-				if parsedIPv6 != nil {
-					createOpts.ContainerNetworkConfig.StaticIPv6 = &parsedIPv6
-				}
+			if staticIPv6 != nil {
+				createOpts.ContainerNetworkConfig.StaticIPv6 = staticIPv6
 			}
-
-			// Process Static MAC configuration
-			if podmanTaskConfig.StaticMAC != "" {
-				parsedMAC, macErr := net.ParseMAC(podmanTaskConfig.StaticMAC)
-				if macErr == nil && parsedMAC != nil {
-					createOpts.ContainerNetworkConfig.StaticMAC = &parsedMAC
-				}
+			if staticMac != nil {
+				createOpts.ContainerNetworkConfig.StaticMAC = &staticMac
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ replace (
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
+	github.com/containers/common v0.63.1
 	github.com/containers/image/v5 v5.35.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-version v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/container-storage-interface/spec v1.11.0 h1:H/YKTOeUZwHtyPOr9raR+HgFm
 github.com/container-storage-interface/spec v1.11.0/go.mod h1:DtUvaQszPml1YJfIK7c00mlv6/g4wNMLanLgiUbKFRI=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/containers/common v0.63.1 h1:6g02gbW34PaRVH4Heb2Pk11x0SdbQ+8AfeKKeQGqYBE=
+github.com/containers/common v0.63.1/go.mod h1:+3GCotSqNdIqM3sPs152VvW7m5+Mg8Kk+PExT3G9hZw=
 github.com/containers/image/v5 v5.35.0 h1:T1OeyWp3GjObt47bchwD9cqiaAm/u4O4R9hIWdrdrP8=
 github.com/containers/image/v5 v5.35.0/go.mod h1:8vTsgb+1gKcBL7cnjyNOInhJQfTUQjJoO2WWkKDoebM=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
@@ -111,8 +113,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
 github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.0 h1:cYSYxd3pw5zd2FSXk2vGdn9igQU2PS8MuxrCOCl0FdY=


### PR DESCRIPTION
This PR addresses rebases https://github.com/hashicorp/nomad-driver-podman/pull/359 and addresses review comments. We'd left the PR open for quite some time and don't want to make the original author come back to fix it now, and permissions on the author's fork don't allow me to push to it. I've retained the original commit and authorship of @zandeez, of course. Original PR description below:

---

Resolve https://github.com/hashicorp/nomad-driver-podman/issues/293 and https://github.com/hashicorp/nomad-driver-podman/issues/358 adding ipv6_address, ipv4_address, static_ips and static_mac options for podman tasks.

Podman API version checks whether to set the properties directly or whether to use the new PerNetworkOptions framework.

ipv6_address and ipv4_address are provided for backwards compatibility, and for compatibility with docker. For Podman 4.0.0 these are merged into static_ips and sent as a PerNetorkOptions entry for the default network.  Added API version
check, static mac support, new array-based option for static IPs to match the podman API

Fixes: https://github.com/hashicorp/nomad-driver-podman/issues/293
Fixes: https://github.com/hashicorp/nomad-driver-podman/issues/358