### PR TITLE
fix HCL validation for static_mac field

### DIFF
--- a/config.go
+++ b/config.go
@@ -106,7 +106,7 @@ var (
 		"ipv4_address": hclspec.NewAttr("ipv4_address", "string", false),
 		"ipv6_address": hclspec.NewAttr("ipv6_address", "string", false),
 		"static_ips":   hclspec.NewAttr("static_ips", "list(string)", false),
-		"static_macs":  hclspec.NewAttr("static_macs", "list(string)", false),
+		"static_mac":   hclspec.NewAttr("static_mac", "string", false),
 		"labels":       hclspec.NewAttr("labels", "list(map(string))", false),
 		"logging": hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"driver":  hclspec.NewAttr("driver", "string", false),


### PR DESCRIPTION
The `static_mac` field was being validated as though it were a list of strings named `static_macs` instead of a single hardware address supported by the Podman API (and the rest of the configuration code).

Fixes: https://github.com/hashicorp/nomad-driver-podman/issues/450
Ref: https://hashicorp.atlassian.net/browse/NMD-882