### PR TITLE
fix: use URLEncoding for X-Registry-Auth header

### DIFF
--- a/registry/authentication.go
+++ b/registry/authentication.go
@@ -109,7 +109,7 @@ func (r *RegistryAuthConfig) SetHeader(headers map[string]string) {
 		if err != nil {
 			return
 		}
-		header := base64.StdEncoding.EncodeToString(b)
+		header := base64.URLEncoding.EncodeToString(b)
 		headers["X-Registry-Auth"] = header
 	}
 }


### PR DESCRIPTION
Podman uses URLEncoding to encode and decode the X-Registry-Auth header. See https://github.com/containers/podman/blob/86dafb60bcb95c8b92e88838e0584bb906239116/pkg/auth/auth.go

The driver encodes the auth header with StdEncoding. This leads to a wrong decoding on some special characters. Happens especially with password.