### PR TITLE
use ContainerKill instead of ContainerStop to StopTask

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -1303,7 +1303,7 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	}
 
 	// fixme send proper signal to container
-	err := handle.podmanClient.ContainerStop(d.ctx, handle.containerID, int(timeout.Seconds()), true)
+	err := handle.podmanClient.ContainerKill(d.ctx, handle.containerID, signal)
 	switch {
 	case err == nil:
 		return nil


### PR DESCRIPTION
I wanted to start a conversation about signal handling -- I noticed that the Docker driver was sending a kill signal to the container instead of the stop command and thought it would be nice if the Podman driver did this as well. I wasn't able to run all of the tests successfully locally on clone, so I'm unsure if this breaks some other expectation.