### PR TITLE
Add support for pasta networking mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+* api: Support pasta network_mode and use it as default for rootless containers on Podman 5.0+ [[GH-476](https://github.com/hashicorp/nomad-driver-podman/pull/476)]
 * build: Update Nomad version to 1.11.0 [[GH-478](https://github.com/hashicorp/nomad-driver-podman/pull/478)]
 * build: Updated to Go 1.25.5 [[GH-477](https://github.com/hashicorp/nomad-driver-podman/pull/477)]
 

--- a/README.md
+++ b/README.md
@@ -404,16 +404,19 @@ config {
 
 * **network_mode** - Set the [network mode](http://docs.podman.io/en/latest/markdown/podman-run.1.html#options) for the container.
 
-By default the task uses the network stack defined in the task group, see [network Stanza](https://www.nomadproject.io/docs/job-specification/network). If the groups network behavior is also undefined, it will fallback to `bridge` in rootful mode or `slirp4netns` for rootless containers.
+By default the task uses the network stack defined in the task group, see [network Stanza](https://www.nomadproject.io/docs/job-specification/network). If the groups network behavior is also undefined, it will fallback to `bridge` in rootful mode, `slirp4netns` for rootless containers on Podman <5.0.0, or `pasta` for rootless containers on Podman >=5.0.0.
 
 * `bridge`: create a network stack on the default podman bridge.
 * `none`: no networking
 * `host`: use the Podman host network stack. Note: the host mode gives the
   container full access to local system services such as D-bus and is therefore
   considered insecure
+* `pasta`: use `pasta` to create a userspace network stack. This is the default
+  for rootless containers on Podman >=5.0.0. Podman currently does not support it for
+  rootful containers: [issue](https://github.com/containers/podman/issues/17840).
 * `slirp4netns`: use `slirp4netns` to create a user network stack. This is the
-  default for rootless containers. Podman currently does not support it for root
-  containers [issue](https://github.com/containers/libpod/issues/6097).
+  default for rootless containers on Podman <5.0.0. Podman currently does not support
+  it for root containers [issue](https://github.com/containers/libpod/issues/6097).
 * `container:id`: reuse another podman containers network stack
 * `task:name-of-other-task`: join the network of another task in the same allocation.
 

--- a/api/structs.go
+++ b/api/structs.go
@@ -372,8 +372,8 @@ type ContainerNetworkConfig struct {
 	// Only available if NetNS is set to bridge.
 	// Optional.
 	StaticMAC *net.HardwareAddr `json:"static_mac,omitempty"`
-	// PortBindings is a set of ports to map into the container.
-	// Only available if NetNS is set to bridge or slirp.
+	// PortMappings is a set of ports to map into the container.
+	// Only available if NetNS is set to bridge, pasta or slirp.
 	// Optional.
 	PortMappings []PortMapping `json:"portmappings,omitempty"`
 	// Expose is a number of ports that will be forwarded to the container
@@ -382,7 +382,7 @@ type ContainerNetworkConfig struct {
 	// protocol. Allowed protocols are "tcp", "udp", and "sctp", or some
 	// combination of the three separated by commas.
 	// If protocol is set to "" we will assume TCP.
-	// Only available if NetNS is set to Bridge or Slirp, and
+	// Only available if NetNS is set to Bridge, Pasta or Slirp, and
 	// PublishExposedPorts is set.
 	// Optional.
 	Expose map[uint16]string `json:"expose,omitempty"`
@@ -423,7 +423,7 @@ type ContainerNetworkConfig struct {
 	// random unused ports (guaranteed to be above 1024) on the host.
 	// This is based on ports set in Expose below, and any ports specified
 	// by the Image (if one is given).
-	// Only available if NetNS is set to Bridge or Slirp.
+	// Only available if NetNS is set to Bridge, Pasta or Slirp.
 	PublishExposedPorts bool `json:"publish_image_ports,omitempty"`
 	// UseImageResolvConf indicates that resolv.conf should not be managed
 	// by Podman, but instead sourced from the image.
@@ -569,6 +569,9 @@ const (
 	// Slirp indicates that a slirp4netns network stack should
 	// be used
 	Slirp NamespaceMode = "slirp4netns"
+	// Pasta indicates that a pasta (successor to slirp4netns)
+	// network stack should be used
+	Pasta NamespaceMode = "pasta"
 	// KeepID indicates a user namespace to keep the owner uid inside
 	// of the namespace itself
 	KeepID NamespaceMode = "keep-id"
@@ -1483,6 +1486,7 @@ type HostInfo struct {
 	RemoteSocket   *RemoteSocket          `json:"remoteSocket,omitempty"`
 	Security       SecurityInfo           `json:"security"`
 	Slirp4NetNS    SlirpInfo              `json:"slirp4netns,omitempty"`
+	Pasta          PastaInfo              `json:"pasta,omitempty"`
 	RuntimeInfo    map[string]interface{} `json:"runtimeInfo,omitempty"`
 	Arch           string                 `json:"arch"`
 	BuildahVersion string                 `json:"buildahVersion"`
@@ -1510,6 +1514,14 @@ type RemoteSocket struct {
 // SlirpInfo describes the slirp executable that
 // is being being used.
 type SlirpInfo struct {
+	Executable string `json:"executable"`
+	Package    string `json:"package"`
+	Version    string `json:"version"`
+}
+
+// PastaInfo describes the pasta executable that
+// is being being used.
+type PastaInfo struct {
 	Executable string `json:"executable"`
 	Package    string `json:"package"`
 	Version    string `json:"version"`

--- a/driver_test.go
+++ b/driver_test.go
@@ -1901,6 +1901,12 @@ func TestPodmanDriver_NetworkModes(t *testing.T) {
 			mode: "slirp4netns",
 		},
 		{
+			// podman doesn't populate network info for pasta mode:
+			// https://github.com/containers/podman/issues/26650
+			mode:    "pasta",
+			gateway: "",
+		},
+		{
 			mode:    "none",
 			gateway: "",
 		},
@@ -1908,6 +1914,9 @@ func TestPodmanDriver_NetworkModes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s_mode_%s", t.Name(), tc.mode), func(t *testing.T) {
+			if os.Geteuid() == 0 && tc.mode == "pasta" {
+				t.Skip("pasta network mode is not supported by podman when run as root")
+			}
 
 			taskCfg := newTaskConfig("", busyboxLongRunningCmd)
 			taskCfg.NetworkMode = tc.mode


### PR DESCRIPTION
Adds support for `pasta` networking mode, which is another user space networking mode, similar to `slirp4netns`. When using the Podman CLI tools, it replaces `slirp4netns` as the default mode for rootless containers in podman >= 5.0.0, and I've adopted the same default behaviour (if no network mode is specified for a task) here.

Closes #345 