### PR TITLE
user namespace: add required ID mappings field when specifying auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+
 * api: Support pasta network_mode and use it as default for rootless containers on Podman 5.0+ [[GH-476](https://github.com/hashicorp/nomad-driver-podman/pull/476)]
 * build: Update Nomad version to 1.11.0 [[GH-478](https://github.com/hashicorp/nomad-driver-podman/pull/478)]
 * build: Updated to Go 1.25.5 [[GH-477](https://github.com/hashicorp/nomad-driver-podman/pull/477)]
+
+BUG FIXES:
+
+* namespaces: Fixed a bug where setting `userns` to `auto` would not correctly configure user/group ID mappings. [[GH-481](https://github.com/hashicorp/nomad-driver-podman/pull/481)]
 
 ## 0.6.3 (June 18, 2025)
 

--- a/api/structs.go
+++ b/api/structs.go
@@ -257,6 +257,10 @@ type ContainerSecurityConfig struct {
 	// If set to private, IDMappings must be set.
 	// Mandatory.
 	UserNS Namespace `json:"userns,omitempty"`
+	// IDMappings are UID and GID mappings that will be used by user
+	// namespaces.
+	// Required if UserNS is private.
+	IDMappings *IDMappingOptions `json:"idmappings,omitempty"`
 	// Groups are a list of supplemental groups the container's user will
 	// be granted access to.
 	// Optional.
@@ -312,12 +316,7 @@ type ContainerSecurityConfig struct {
 	// If ALL is passed, all paths will be unmasked.
 	// Optional.
 	Unmask []string `json:"unmask,omitempty"`
-	// IDMappings are UID and GID mappings that will be used by user
-	// namespaces.
-	// Required if UserNS is private.
-	// IDMappings *storage.IDMappingOptions `json:"idmappings,omitempty"`
 	// ReadOnlyFilesystem indicates that everything will be mounted
-
 	// as read-only
 	ReadOnlyFilesystem bool `json:"read_only_filesystem,omitempty"`
 }
@@ -586,6 +585,53 @@ const (
 type Namespace struct {
 	NSMode NamespaceMode `json:"nsmode,omitempty"`
 	Value  string        `json:"value,omitempty"`
+}
+
+// ------------------------------------------------------------------------------------
+// structs copied from https://pkg.go.dev/go.podman.io/storage/types#IDMappingOptions
+
+type IDMappingOptions struct {
+	// UIDMap and GIDMap are used for setting up a layer's root filesystem
+	// for use inside of a user namespace where ID mapping is being used.
+	// If HostUIDMapping/HostGIDMapping is true, no mapping of the
+	// respective type will be used.  Otherwise, if UIDMap and/or GIDMap
+	// contain at least one mapping, one or both will be used.  By default,
+	// if neither of those conditions apply, if the layer has a parent
+	// layer, the parent layer's mapping will be used, and if it does not
+	// have a parent layer, the mapping which was passed to the Store
+	// object when it was initialized will be used.
+	HostUIDMapping bool
+	HostGIDMapping bool
+	UIDMap         []IDMap
+	GIDMap         []IDMap
+	AutoUserNs     bool
+	AutoUserNsOpts AutoUserNsOptions
+}
+
+type AutoUserNsOptions struct {
+	// Size defines the size for the user namespace.  If it is set to a
+	// value bigger than 0, the user namespace will have exactly this size.
+	// If it is not set, some heuristics will be used to find its size.
+	Size uint32
+	// InitialSize defines the minimum size for the user namespace.
+	// The created user namespace will have at least this size.
+	InitialSize uint32
+	// PasswdFile to use if the container uses a volume.
+	PasswdFile string
+	// GroupFile to use if the container uses a volume.
+	GroupFile string
+	// AdditionalUIDMappings specified additional UID mappings to include in
+	// the generated user namespace.
+	AdditionalUIDMappings []IDMap
+	// AdditionalGIDMappings specified additional GID mappings to include in
+	// the generated user namespace.
+	AdditionalGIDMappings []IDMap
+}
+
+type IDMap struct {
+	ContainerID int `json:"container_id"`
+	HostID      int `json:"host_id"`
+	Size        int `json:"size"`
 }
 
 // -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When using a private user namespace, we need to include the `IDMappings` block in the create container's request. This block includes UID and GID mappings parsed out of the string the user gives us. Without it, specifying an `"auto"` configuration silently fails to wire up the correct mappings.

This implementation doesn't include additional UID/GID mappings, as we don't have that configuration option.

Fixes: https://github.com/hashicorp/nomad-driver-podman/issues/470

---

**Testing**

Running rootless Nomad and rootless podman, I deployed the following jobspec:

```hcl
job "example" {

  group "web" {

    network {
      port "www" { to = 8001 }
    }

    task "http" {

      driver = "podman"

      config {
        image = "docker.io/library/busybox:latest"
        command = "httpd"
        args    = ["-v", "-f", "-p", "8001", "-h", "/var/www"]
        userns  = "auto:uidmapping=33:1000:1,gidmapping=33:1001:1"
        ports = ["www"]
      }

      resources {
        cpu    = 100
        memory = 128
      }

    }
  }
}
```

Resulting container:

```
$ podman inspect c87 | jq '.[0].HostConfig.IDMappings'
{
  "UidMap": [
    "0:1:33",
    "34:34:966",
    "1000:1001:64535",
    "33:1000:1"
  ],
  "GidMap": [
    "0:1:33",
    "34:34:967",
    "1001:1002:64534",
    "33:1001:1"
  ]
}
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

