### PR TITLE
feat: Support storage_opt like docker driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,16 @@ config {
 }
 ```
 
+* **storage_opt** - (Optional) A key-value map of storage options set on container start.
+
+```hcl
+config {
+  storage_opt = {
+    size = "40G"
+  }
+}
+```
+
 * **ulimit** - (Optional) A key-value map of ulimit configurations to set to the containers to start.
 
 ```hcl

--- a/api/structs.go
+++ b/api/structs.go
@@ -222,6 +222,9 @@ type ContainerStorageConfig struct {
 	// Devices are devices that will be added to the container.
 	// Optional.
 	Devices []spec.LinuxDevice `json:"devices,omitempty"`
+	// StorageOpts are storage driver options.
+	// Optional.
+	StorageOpts map[string]string `json:"storage_opts,omitempty"`
 	// IpcNS is the container's IPC namespace.
 	// Default is private.
 	// Conflicts with ShmSize if not set to private.

--- a/config.go
+++ b/config.go
@@ -144,6 +144,7 @@ var (
 		"volumes":         hclspec.NewAttr("volumes", "list(string)", false),
 		"force_pull":      hclspec.NewAttr("force_pull", "bool", false),
 		"readonly_rootfs": hclspec.NewAttr("readonly_rootfs", "bool", false),
+		"storage_opt":     hclspec.NewBlockAttrs("storage_opt", "string", false),
 		"userns":          hclspec.NewAttr("userns", "string", false),
 		"shm_size":        hclspec.NewAttr("shm_size", "string", false),
 	})
@@ -272,6 +273,7 @@ type TaskConfig struct {
 	ForcePull         bool               `codec:"force_pull"`
 	Privileged        bool               `codec:"privileged"`
 	ReadOnlyRootfs    bool               `codec:"readonly_rootfs"`
+	StorageOpt        map[string]string  `codec:"storage_opt"`
 	UserNS            string             `codec:"userns"`
 	ShmSize           string             `codec:"shm_size"`
 	SecurityOpt       []string           `codec:"security_opt"`

--- a/config_test.go
+++ b/config_test.go
@@ -72,6 +72,24 @@ func TestConfig_Labels(t *testing.T) {
 	must.Eq(t, "job", tc.Labels["nomad"])
 }
 
+func TestConfig_StorageOpt(t *testing.T) {
+	ci.Parallel(t)
+
+	parser := hclutils.NewConfigParser(taskConfigSpec)
+	validHCL := `
+  config {
+	  image = "docker://redis"
+		storage_opt {
+		  size = "1G"
+		}
+  }
+`
+
+	var tc *TaskConfig
+	parser.ParseHCL(t, validHCL, &tc)
+	must.Eq(t, "1G", tc.StorageOpt["size"])
+}
+
 func TestConfig_ForcePull(t *testing.T) {
 	ci.Parallel(t)
 

--- a/driver.go
+++ b/driver.go
@@ -654,6 +654,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	createOpts.ContainerStorageConfig.Image = podmanTaskConfig.Image
 	createOpts.ContainerStorageConfig.InitPath = podmanTaskConfig.InitPath
 	createOpts.ContainerStorageConfig.WorkDir = podmanTaskConfig.WorkingDir
+	createOpts.ContainerStorageConfig.StorageOpts = podmanTaskConfig.StorageOpt
 	allMounts, err := d.containerMounts(cfg, &podmanTaskConfig)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Taking inspiration from https://github.com/hashicorp/nomad/pull/4908 this MR adds support for specifying a storage_opt block in the Nomad job.

Available storage options can be found here
https://manpages.debian.org/experimental/containers-storage/containers-storage.conf.5.en.html

Note some options are only available on certain backing stores. For example, the `size` option is not supported on ext4 by Podman yet, even though the Linux kernel nowadays supports it.