### PR TITLE
ci: declare permissions on jira-sync and tests

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -10,6 +10,12 @@ on:
 
 name: Jira Issue Sync
 
+# Jira mirror only reads issue/comment metadata; all writes go to Jira
+# via JIRA_API_TOKEN.
+permissions:
+  issues: read
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ on:
       - 'README.md'
       - 'Vagrantfile'
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` on the two workflows that were inheriting org defaults:

- **jira-sync.yml** — `issues: read` + `contents: read`. The Jira mirror reads issue/comment metadata and writes everything to Jira via `JIRA_API_TOKEN` (gajira-login / gh-action-jira-create / gajira-transition / etc). The GitHub token doesn't need any write scopes.
- **tests.yml** — `contents: read`. Plain CI run that checks out source and runs the test suite.

YAML validated with `yaml.safe_load` on each edited file.