### PR TITLE
api: close response body on non-200 from ContainerLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 * config: Adds support for plugin configuration `networking.default_rootless_mode` to override the default networking mode when run rootlessly. [[GH-495](https://github.com/hashicorp/nomad-driver-podman/pull/495)]
 
 BUG FIXES:
+* api: Fixed file descriptor leak when getting logs from the task [[GH-508](https://github.com/hashicorp/nomad-driver-podman/pull/508)]
 * driver: Fixed static IP configuration (`static_ips`, `ipv4_address`, `ipv6_address`, `static_mac`) being silently ignored, corrected related per-network map handling and `driverNet.IP` resolution for service discovery. [[GH-507](https://github.com/hashicorp/nomad-driver-podman/pull/507)]
 
 ## 0.6.4 (December 10, 2025)

--- a/api/container_logs.go
+++ b/api/container_logs.go
@@ -20,15 +20,15 @@ func (c *API) ContainerLogs(ctx context.Context, name string, since time.Time, s
 	if err != nil {
 		return err
 	}
+	defer func() {
+		ignoreClose(res.Body)
+		c.logger.Debug("Stopped log stream", "container", name)
+	}()
 
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("cannot get logs from container, status code: %d", res.StatusCode)
 	}
 
-	defer func() {
-		ignoreClose(res.Body)
-		c.logger.Debug("Stopped log stream", "container", name)
-	}()
 	buffer := make([]byte, 1024)
 	for {
 		fd, l, err := DemuxHeader(res.Body, buffer)


### PR DESCRIPTION
The defer that closes res.Body was registered after the status-code check, so any non-200 response returned without closing the body and leaked the underlying connection. Combined with retry loops in the task driver that call ContainerLogs repeatedly, this can exhaust file descriptors on the driver process.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No