### PR TITLE
added support for custom Podman network names 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 * config: Adds support for plugin configuration `networking.default_rootless_mode` to override the default networking mode when run rootlessly. [[GH-495](https://github.com/hashicorp/nomad-driver-podman/pull/495)]
-* config: Support custom Podman network names for static IP/MAC options via `network_mode`. [[GH-TBD](https://github.com/hashicorp/nomad-driver-podman/pull/TBD)]
+* config: Support custom Podman network names for static IP/MAC options via `network_mode`. [[GH-509](https://github.com/hashicorp/nomad-driver-podman/pull/509)]
 
 BUG FIXES:
 * driver: Fixed static IP configuration (`static_ips`, `ipv4_address`, `ipv6_address`, `static_mac`) being silently ignored, corrected related per-network map handling and `driverNet.IP` resolution for service discovery. [[GH-507](https://github.com/hashicorp/nomad-driver-podman/pull/507)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 * config: Adds support for plugin configuration `networking.default_rootless_mode` to override the default networking mode when run rootlessly. [[GH-495](https://github.com/hashicorp/nomad-driver-podman/pull/495)]
+* config: Support custom Podman network names for static IP/MAC options via `network_mode`. [[GH-TBD](https://github.com/hashicorp/nomad-driver-podman/pull/TBD)]
 
 BUG FIXES:
 * driver: Fixed static IP configuration (`static_ips`, `ipv4_address`, `ipv6_address`, `static_mac`) being silently ignored, corrected related per-network map handling and `driverNet.IP` resolution for service discovery. [[GH-507](https://github.com/hashicorp/nomad-driver-podman/pull/507)]

--- a/README.md
+++ b/README.md
@@ -419,6 +419,9 @@ By default the task uses the network stack defined in the task group, see [netwo
   it for root containers [issue](https://github.com/containers/libpod/issues/6097).
 * `container:id`: reuse another podman containers network stack
 * `task:name-of-other-task`: join the network of another task in the same allocation.
+* `custom-network-name`: attach the container to a pre-existing Podman network
+  created with `podman network create`. The network must already exist or the task
+  will fail with a clear error. Requires Podman >= 4.0.
 
 ```hcl
 config {

--- a/api/network_exists.go
+++ b/api/network_exists.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // NetworkExists checks if a Podman network with the given name exists.
@@ -15,7 +16,7 @@ import (
 // Unlike other endpoints that work with /v1.0.0, this one requires /v4.0.0+.
 func (c *API) NetworkExists(ctx context.Context, name string) (bool, error) {
 
-	res, err := c.Get(ctx, fmt.Sprintf("/v4.0.0/libpod/networks/%s/exists", name))
+	res, err := c.Get(ctx, fmt.Sprintf("/v4.0.0/libpod/networks/%s/exists", url.PathEscape(name)))
 	if err != nil {
 		return false, err
 	}

--- a/api/network_exists.go
+++ b/api/network_exists.go
@@ -1,0 +1,33 @@
+// Copyright IBM Corp. 2019, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// NetworkExists checks if a Podman network with the given name exists.
+// Returns true if the network exists (HTTP 204), false if not found (HTTP 404).
+// Note: The /networks/{name}/exists endpoint was introduced in Podman API v4.
+// Unlike other endpoints that work with /v1.0.0, this one requires /v4.0.0+.
+func (c *API) NetworkExists(ctx context.Context, name string) (bool, error) {
+
+	res, err := c.Get(ctx, fmt.Sprintf("/v4.0.0/libpod/networks/%s/exists", name))
+	if err != nil {
+		return false, err
+	}
+
+	defer ignoreClose(res.Body)
+
+	switch res.StatusCode {
+	case http.StatusNoContent:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status code checking network %q: %d", name, res.StatusCode)
+	}
+}

--- a/api/network_exists_test.go
+++ b/api/network_exists_test.go
@@ -1,0 +1,33 @@
+// Copyright IBM Corp. 2019, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestApi_Network_Exists(t *testing.T) {
+	api := newApi()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	testCases := []struct {
+		Name        string
+		NetworkName string
+		Exists      bool
+	}{
+		{Name: "default podman network exists", NetworkName: "podman", Exists: true},
+		{Name: "non-existent network returns false", NetworkName: "this-network-does-not-exist-xyz", Exists: false},
+	}
+
+	for _, testCase := range testCases {
+		exists, err := api.NetworkExists(ctx, testCase.NetworkName)
+		must.NoError(t, err)
+		must.Eq(t, testCase.Exists, exists)
+	}
+}

--- a/driver.go
+++ b/driver.go
@@ -781,6 +781,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		}
 	}
 	// Configure network
+	networkName := "default"
 	if cfg.NetworkIsolation != nil && cfg.NetworkIsolation.Path != "" {
 		createOpts.ContainerNetworkConfig.NetNS.NSMode = api.Path
 		createOpts.ContainerNetworkConfig.NetNS.Value = cfg.NetworkIsolation.Path
@@ -832,7 +833,24 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			createOpts.ContainerNetworkConfig.NetNS.NSMode = api.FromContainer
 			createOpts.ContainerNetworkConfig.NetNS.Value = BuildContainerNameForTask(otherTaskName, cfg)
 		default:
-			return nil, nil, fmt.Errorf("Unknown/Unsupported network mode: %s", podmanTaskConfig.NetworkMode)
+			// Treat any unrecognized value as a custom Podman network name
+			// (e.g., one created via "podman network create mynet").
+			// Custom networks are bridged networks under the hood, so we set
+			// NSMode = Bridge and specify the network name in the Networks map.
+			// NetworkExists requires Podman API v4+
+			exists, netErr := podmanClient.NetworkExists(d.ctx, podmanTaskConfig.NetworkMode)
+			if netErr != nil {
+				return nil, nil, fmt.Errorf("failed to check network %q: %w", podmanTaskConfig.NetworkMode, netErr)
+			}
+			if !exists {
+				return nil, nil, fmt.Errorf("network %q not found, verify with: podman network ls", podmanTaskConfig.NetworkMode)
+			}
+			d.logger.Debug("Using custom network", "network", podmanTaskConfig.NetworkMode)
+			createOpts.ContainerNetworkConfig.NetNS.NSMode = api.Bridge
+			networkName = podmanTaskConfig.NetworkMode
+			// Always populate the Networks map for custom networks so Podman
+			// attaches to the correct network, not just the default bridge.
+			createOpts.Networks = map[string]api.PerNetworkOptions{networkName: {}}
 		}
 	}
 
@@ -895,7 +913,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			// Only bridge mode uses named networks; other modes (host, slirp4netns,
 			// none, task:*, container:*, ns:*) don't honor per-network options.
 			if createOpts.ContainerNetworkConfig.NetNS.NSMode == api.Bridge {
-				createOpts.Networks = map[string]api.PerNetworkOptions{"default": netOpts}
+				createOpts.Networks = map[string]api.PerNetworkOptions{networkName: netOpts}
 			}
 		} else {
 			// Before version 4, there were StaticIP, StaticIPv6 and StaticMAC properties
@@ -1016,7 +1034,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	// Resolve the container IP. For the default bridge network, Podman
 	// populates the top-level IPAddress field. For named networks it is
 	// empty and the IP lives in the per-network map instead.
-	containerIP := resolveContainerIP(inspectData.NetworkSettings, "default")
+	containerIP := resolveContainerIP(inspectData.NetworkSettings, networkName)
 
 	driverNet := &drivers.DriverNetwork{
 		PortMap:       podmanTaskConfig.PortMap,

--- a/driver_test.go
+++ b/driver_test.go
@@ -2989,3 +2989,104 @@ func TestResolveContainerIP(t *testing.T) {
 		})
 	}
 }
+
+// TestPodmanDriver_CustomNetwork validates custom network_mode behavior:
+// successful attachment, non-existent network error, and unreachable socket error.
+func TestPodmanDriver_CustomNetwork(t *testing.T) {
+	ci.Parallel(t)
+
+	// Create a temporary network for the success case
+	networkName := fmt.Sprintf("test-net-%s", uuid.Generate()[:8])
+	out, err := exec.Command("podman", "network", "create", networkName).CombinedOutput()
+	if err != nil {
+		t.Skipf("Cannot create test network (podman not available?): %s: %s", err, out)
+	}
+	defer func() {
+		_, _ = exec.Command("podman", "network", "rm", networkName).CombinedOutput()
+	}()
+
+	testCases := []struct {
+		name          string
+		networkMode   string
+		harnessConfig map[string]interface{}
+		expectErr     bool
+		errContains   []string
+		verifyNetwork bool // if true, inspect container to verify network attachment
+	}{
+		{
+			name:          "attaches to custom network without static IP",
+			networkMode:   networkName,
+			expectErr:     false,
+			verifyNetwork: true,
+		},
+		{
+			name:        "non-existent network returns clear error",
+			networkMode: "this-network-definitely-does-not-exist-xyz",
+			expectErr:   true,
+			errContains: []string{"not found", "podman network ls"},
+		},
+		{
+			name:        "unreachable socket hints at version requirement",
+			networkMode: "some-custom-network",
+			harnessConfig: map[string]interface{}{
+				"Socket": []PluginSocketConfig{{
+					Name:       "default",
+					SocketPath: "unix:///tmp/nonexistent-podman-socket-test.sock",
+				}},
+			},
+			expectErr:   true,
+			errContains: []string{"failed to check network", "requires Podman >= 4.0"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			taskCfg := newTaskConfig("", busyboxLongRunningCmd)
+			taskCfg.NetworkMode = tc.networkMode
+
+			task := &drivers.TaskConfig{
+				ID:        uuid.Generate(),
+				Name:      "custom_net_test",
+				AllocID:   uuid.Generate(),
+				Resources: createBasicResources(),
+			}
+			must.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+			d := podmanDriverHarness(t, tc.harnessConfig)
+			cleanup := d.MkAllocDir(task, true)
+			defer cleanup()
+
+			containerName := BuildContainerName(task)
+			_, network, err := d.StartTask(task)
+
+			if tc.expectErr {
+				must.Error(t, err)
+				for _, substr := range tc.errContains {
+					must.StrContains(t, err.Error(), substr)
+				}
+				return
+			}
+
+			must.NoError(t, err)
+			defer func() {
+				_ = d.DestroyTask(task.ID, true)
+			}()
+
+			if tc.verifyNetwork {
+				must.NoError(t, d.WaitUntilStarted(task.ID, 20*time.Second))
+
+				inspectData, inspectErr := getPodmanDriver(t, d).defaultPodman.ContainerInspect(context.Background(), containerName)
+				must.NoError(t, inspectErr)
+
+				// Container must be on the expected network
+				_, hasNetwork := inspectData.NetworkSettings.Networks[tc.networkMode]
+				must.True(t, hasNetwork, must.Sprintf("expected container on network %q, got: %v", tc.networkMode, inspectData.NetworkSettings.Networks))
+
+				// Driver-reported IP must match the network's IP
+				netData := inspectData.NetworkSettings.Networks[tc.networkMode]
+				must.Eq(t, netData.IPAddress, network.IP)
+				must.NotEq(t, "", network.IP)
+			}
+		})
+	}
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -3035,7 +3035,7 @@ func TestPodmanDriver_CustomNetwork(t *testing.T) {
 				}},
 			},
 			expectErr:   true,
-			errContains: []string{"failed to check network", "requires Podman >= 4.0"},
+			errContains: []string{"failed to check network"},
 		},
 	}
 


### PR DESCRIPTION
Fixes: [#1518](https://hashicorp.atlassian.net/browse/NMD-1518)

**_Summary_**

Adds support for using pre-existing Podman networks (created with podman network create) directly via network_mode. Previously, any value that wasn't a known keyword (bridge, host, none, slirp4netns, pasta, container:*, task:*, ns:*) would cause Unknown/Unsupported network mode error.

```
config {
  image        = "alpine:latest"
  network_mode = "mynet"       # ← now works
  static_ips   = ["10.89.2.50"] # ← optional
}
```

**_Root Cause_**

The default: case in the network mode switch returned an unconditional error:

```
default:
    return nil, nil, fmt.Errorf("Unknown/Unsupported network mode: %s", podmanTaskConfig.NetworkMode)
```

There was no path to attach containers to user-created networks. Additionally, even after [PR #507](https://github.com/hashicorp/nomad-driver-podman/pull/507) fixed static IPs, the Networks map was only populated inside the static IP block — meaning custom networks without static IPs silently fell back to the default bridge.

**Previous Flow vs After Flow**
Step | Before (Broken) | After (Fixed)
-- | -- | --
User sets network_mode = "mynet" | Hits default: case | Hits default: case
Invalid network name | Generic "Unknown/Unsupported" error | Clear: network "X" not found, verify with: podman network ls
NSMode assignment |  Never reached | Set to Bridge (custom networks are bridged networks)
Networks map |  Never set |  {"mynet": {}} — tells Podman which network to join
Container placement |  Error, container never starts | Container attached to correct network
Custom network + static IP | Error | Networks map overwritten with {"mynet": {static_ips: [...]}}
Custom network without static IP | Error | Networks: {"mynet": {}} — gets DHCP IP on correct network
IP resolution (driverNet.IP) | N/A | resolveContainerIP() checks Networks["mynet"].IPAddress

**_Major Changes_**
- driver.go ->  default: case validates network, sets NSMode=Bridge, populates Networks map, uses dynamic networkName for IP resolution
- network_exists.go -> New — NetworkExists() calls /v4.0.0/libpod/networks/{name}/exists

**Testing:**
<details>

1. test-custom-network.nomad
```
==> 2026-06-01T15:11:09+05:30: Monitoring deployment "6284b914"
  ✓ Deployment "6284b914" successful
    
    2026-06-01T15:11:09+05:30
    ID          = 6284b914
    Job ID      = test-custom-network
    Job Version = 0
    Status      = successful
    Description = Deployment completed successfully
    
    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    test        1        1       1        0
    2026-06-01T15:20:26+05:30
=== PROOF: Network name must be testnet6, NOT podman ===

Network: testnet6 | IPv4: 10.89.2.8
```

2. test-custom-network-static.nomad
```
==> 2026-06-01T15:12:00+05:30: Monitoring deployment "dfbd856d"
  ✓ Deployment "dfbd856d" successful
    
    2026-06-01T15:12:11+05:30
    ID          = dfbd856d
    Job ID      = test-custom-network-static
    Job Version = 0
    Status      = successful
    Description = Deployment completed successfully
    
    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    test        1        1       1        0
    2026-06-01T15:22:09+05:30
=== PROOF: Must be testnet6 with EXACT IP 10.89.2.50 ===
Network: testnet6 | IPv4: 10.89.2.50
```

3. test-custom-network-bad.nomad
```
2026-06-01T15:21:44+05:30  Not Restarting  Error was unrecoverable
2026-06-01T15:21:44+05:30  Driver Failure  rpc error: code = Unknown desc = network "does-not-exist" not found, verify with: podman network ls
```


Test Job | Expected | Result
-- | -- | --
network_mode = "testnet6" (no static IP) | Container on testnet6 | ✅ Network: testnet6 \| IPv4: 10.89.2.8
network_mode = "testnet6" + static_ips = ["10.89.2.50"] | Exact IP on testnet6 | ✅ Network: testnet6 \| IPv4: 10.89.2.50
network_mode = "does-not-exist" | Driver Failure | ✅ network "does-not-exist" not found, verify with: podman network ls

</details>






<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

