### PR TITLE
fix: allow conmon to write logs to FIFO when podman runs as non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ IMPROVEMENTS:
 BUG FIXES:
 * api: Fixed file descriptor leak when getting logs from the task [[GH-508](https://github.com/hashicorp/nomad-driver-podman/pull/508)]
 * driver: Fixed static IP configuration (`static_ips`, `ipv4_address`, `ipv6_address`, `static_mac`) being silently ignored, corrected related per-network map handling and `driverNet.IP` resolution for service discovery. [[GH-507](https://github.com/hashicorp/nomad-driver-podman/pull/507)]
-* driver: Fixed log FIFO permission denied error when using rootless podman. [[GH-510](https://github.com/hashicorp/nomad-driver-podman/pull/510)]
+* driver: Fixed log FIFO permission denied error when using rootless podman with Nomad run as root. [[GH-510](https://github.com/hashicorp/nomad-driver-podman/pull/510)]
 
 ## 0.6.4 (December 10, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 BUG FIXES:
 * api: Fixed file descriptor leak when getting logs from the task [[GH-508](https://github.com/hashicorp/nomad-driver-podman/pull/508)]
 * driver: Fixed static IP configuration (`static_ips`, `ipv4_address`, `ipv6_address`, `static_mac`) being silently ignored, corrected related per-network map handling and `driverNet.IP` resolution for service discovery. [[GH-507](https://github.com/hashicorp/nomad-driver-podman/pull/507)]
+* driver: Fixed log FIFO permission denied error when using rootless podman. [[GH-510](https://github.com/hashicorp/nomad-driver-podman/pull/510)]
 
 ## 0.6.4 (December 10, 2025)
 

--- a/api/api.go
+++ b/api/api.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/api.go
+++ b/api/api.go
@@ -19,6 +19,7 @@ import (
 type API struct {
 	apiVersion       string
 	baseUrl          string
+	socketPath       string
 	defaultPodman    bool
 	appArmor         bool
 	cgroupV2         bool
@@ -54,6 +55,7 @@ func NewClient(logger hclog.Logger, config ClientConfig) *API {
 	ac := &API{
 		logger:        logger,
 		defaultPodman: config.DefaultPodman,
+		socketPath:    config.SocketPath,
 	}
 
 	ac.logger.Debug("http baseurl", "url", config.SocketPath)
@@ -107,6 +109,10 @@ func (c *API) SetRootless(isRootless bool) {
 
 func (c *API) IsRootless() bool {
 	return c.rootless
+}
+
+func (c *API) GetSocketPath() string {
+	return c.socketPath
 }
 
 func (c *API) SetAppArmor(appArmorEnabled bool) {

--- a/api/container_logs.go
+++ b/api/container_logs.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/driver.go
+++ b/driver.go
@@ -1965,12 +1965,15 @@ func resolveContainerIP(networkSettings *api.InspectNetworkSettings, networkName
 
 // ensureFifoAccessible ensures the log FIFO at fifoPath can be written to by
 // the rootless podman user. It determines the podman user by stat-ing the unix
-// socket file and chowns the FIFO to that user. Falls back to chmod 0666 if
-// the user cannot be determined. No-op when podman is running as root.
+// socket file and chowns the FIFO to that user. No-op when podman is running
+// as root or when the socket owner cannot be determined (e.g. TCP socket).
 func ensureFifoAccessible(logger hclog.Logger, fifoPath string, podmanClient *api.API) error {
+	// Nothing to do if log collection is disabled (no FIFO path configured).
 	if fifoPath == "" {
 		return nil
 	}
+	// Rootful podman: conmon runs as root and can already write to the
+	// root-owned FIFO, so no ownership change is needed.
 	if !podmanClient.IsRootless() {
 		return nil
 	}
@@ -1979,14 +1982,13 @@ func ensureFifoAccessible(logger hclog.Logger, fifoPath string, podmanClient *ap
 
 	if ok {
 		if err := os.Chown(fifoPath, uid, gid); err != nil {
-			logger.Warn("failed to chown fifo, falling back to chmod", "path", fifoPath, "error", err)
+			logger.Warn("failed to chown fifo", "path", fifoPath, "error", err)
 			return os.Chmod(fifoPath, 0666)
 		}
 	} else {
-		// Socket owner unknown (TCP or stat failed) — fallback to world-writable
-		if err := os.Chmod(fifoPath, 0666); err != nil {
-			return fmt.Errorf("failed to chmod fifo %s: %w", fifoPath, err)
-		}
+		// Cannot determine socket owner (TCP/HTTP socket or stat failed) — skip.
+		// Rootless podman over non-unix sockets is unsupported for log FIFOs.
+		logger.Debug("cannot determine podman socket owner, skipping fifo chown", "path", fifoPath)
 	}
 
 	return nil

--- a/driver.go
+++ b/driver.go
@@ -1003,13 +1003,17 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	if !recoverRunningContainer {
 		// Ensure log FIFOs are accessible by the rootless podman user before starting
 		// the container. Nomad's logmon creates FIFOs owned by root:root with 0600;
-		// conmon (running as the podman user) needs write access.
+		// conmon (running as the podman user) needs write access. If chown fails,
+		// ContainerStart will also fail (conmon crashes with EACCES), so return
+		// early with a clearer error message.
 		if createOpts.LogConfiguration.Driver == "k8s-file" {
 			if fifoErr := ensureFifoAccessible(d.logger, cfg.StdoutPath, podmanClient); fifoErr != nil {
-				d.logger.Warn("failed to make stdout fifo accessible", "error", fifoErr)
+				cleanup()
+				return nil, nil, fmt.Errorf("failed to make stdout fifo accessible: %w", fifoErr)
 			}
 			if fifoErr := ensureFifoAccessible(d.logger, cfg.StderrPath, podmanClient); fifoErr != nil {
-				d.logger.Warn("failed to make stderr fifo accessible", "error", fifoErr)
+				cleanup()
+				return nil, nil, fmt.Errorf("failed to make stderr fifo accessible: %w", fifoErr)
 			}
 		}
 
@@ -1967,6 +1971,10 @@ func resolveContainerIP(networkSettings *api.InspectNetworkSettings, networkName
 // the rootless podman user. It determines the podman user by stat-ing the unix
 // socket file and chowns the FIFO to that user. No-op when podman is running
 // as root or when the socket owner cannot be determined (e.g. TCP socket).
+//
+// Uses os.Root to open the FIFO without following symlinks, preventing a
+// symlink swap attack where a restarted task replaces the FIFO with a symlink
+// to an arbitrary file.
 func ensureFifoAccessible(logger hclog.Logger, fifoPath string, podmanClient *api.API) error {
 	// Nothing to do if log collection is disabled (no FIFO path configured).
 	if fifoPath == "" {
@@ -1981,7 +1989,27 @@ func ensureFifoAccessible(logger hclog.Logger, fifoPath string, podmanClient *ap
 	uid, gid, ok := getSocketOwner(podmanClient.GetSocketPath())
 
 	if ok {
-		if err := os.Chown(fifoPath, uid, gid); err != nil {
+		// Open the FIFO's parent directory as a root to prevent symlink traversal.
+		dir := filepath.Dir(fifoPath)
+		base := filepath.Base(fifoPath)
+
+		root, err := os.OpenRoot(dir)
+		if err != nil {
+			return fmt.Errorf("failed to open fifo parent directory %q: %w", dir, err)
+		}
+		defer root.Close()
+
+		// Open the FIFO itself without following symlinks (os.Root enforces this).
+		// O_RDONLY|O_NONBLOCK avoids blocking on the FIFO (no writer needed).
+		// We only need a valid fd for fchown, not actual I/O.
+		f, err := root.OpenFile(base, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+		if err != nil {
+			return fmt.Errorf("failed to open fifo %q: %w", fifoPath, err)
+		}
+		defer f.Close()
+
+		// Fchown on the file descriptor — safe from TOCTOU/symlink attacks.
+		if err := f.Chown(uid, gid); err != nil {
 			return err
 		}
 	} else {
@@ -1999,6 +2027,9 @@ func getSocketOwner(socketPath string) (int, int, bool) {
 	if !strings.HasPrefix(socketPath, "unix:") {
 		return 0, 0, false
 	}
+	// Two TrimPrefix calls handle both forms of the unix socket URI:
+	// "unix:/run/user/1001/podman/podman.sock"   → strip "unix:"
+	// "unix:///run/user/1001/podman/podman.sock"  → strip "unix:" then "//"
 	sockFile := strings.TrimPrefix(socketPath, "unix:")
 	sockFile = strings.TrimPrefix(sockFile, "//")
 

--- a/driver.go
+++ b/driver.go
@@ -1982,7 +1982,6 @@ func ensureFifoAccessible(logger hclog.Logger, fifoPath string, podmanClient *ap
 
 	if ok {
 		if err := os.Chown(fifoPath, uid, gid); err != nil {
-			logger.Warn("failed to chown fifo", "path", fifoPath, "error", err)
 			return err
 		}
 	} else {

--- a/driver.go
+++ b/driver.go
@@ -1005,11 +1005,11 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		// the container. Nomad's logmon creates FIFOs owned by root:root with 0600;
 		// conmon (running as the podman user) needs write access.
 		if createOpts.LogConfiguration.Driver == "k8s-file" {
-			if err := ensureFifoAccessible(d.logger, cfg.StdoutPath, podmanClient); err != nil {
-				d.logger.Warn("failed to make stdout fifo accessible", "error", err)
+			if fifoErr := ensureFifoAccessible(d.logger, cfg.StdoutPath, podmanClient); fifoErr != nil {
+				d.logger.Warn("failed to make stdout fifo accessible", "error", fifoErr)
 			}
-			if err := ensureFifoAccessible(d.logger, cfg.StderrPath, podmanClient); err != nil {
-				d.logger.Warn("failed to make stderr fifo accessible", "error", err)
+			if fifoErr := ensureFifoAccessible(d.logger, cfg.StderrPath, podmanClient); fifoErr != nil {
+				d.logger.Warn("failed to make stderr fifo accessible", "error", fifoErr)
 			}
 		}
 

--- a/driver.go
+++ b/driver.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/armon/circbuf"
@@ -1000,6 +1001,18 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	}
 
 	if !recoverRunningContainer {
+		// Ensure log FIFOs are accessible by the rootless podman user before starting
+		// the container. Nomad's logmon creates FIFOs owned by root:root with 0600;
+		// conmon (running as the podman user) needs write access.
+		if createOpts.LogConfiguration.Driver == "k8s-file" {
+			if err := ensureFifoAccessible(d.logger, cfg.StdoutPath, podmanClient); err != nil {
+				d.logger.Warn("failed to make stdout fifo accessible", "error", err)
+			}
+			if err := ensureFifoAccessible(d.logger, cfg.StderrPath, podmanClient); err != nil {
+				d.logger.Warn("failed to make stderr fifo accessible", "error", err)
+			}
+		}
+
 		if startErr := podmanClient.ContainerStart(d.ctx, containerID); startErr != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("failed to start task, could not start container: %w", startErr)
@@ -1948,4 +1961,53 @@ func resolveContainerIP(networkSettings *api.InspectNetworkSettings, networkName
 		return netData.IPAddress
 	}
 	return ""
+}
+
+// ensureFifoAccessible ensures the log FIFO at fifoPath can be written to by
+// the rootless podman user. It determines the podman user by stat-ing the unix
+// socket file and chowns the FIFO to that user. Falls back to chmod 0666 if
+// the user cannot be determined. No-op when podman is running as root.
+func ensureFifoAccessible(logger hclog.Logger, fifoPath string, podmanClient *api.API) error {
+	if fifoPath == "" {
+		return nil
+	}
+	if !podmanClient.IsRootless() {
+		return nil
+	}
+
+	uid, gid, ok := getSocketOwner(podmanClient.GetSocketPath())
+
+	if ok {
+		if err := os.Chown(fifoPath, uid, gid); err != nil {
+			logger.Warn("failed to chown fifo, falling back to chmod", "path", fifoPath, "error", err)
+			return os.Chmod(fifoPath, 0666)
+		}
+	} else {
+		// Socket owner unknown (TCP or stat failed) — fallback to world-writable
+		if err := os.Chmod(fifoPath, 0666); err != nil {
+			return fmt.Errorf("failed to chmod fifo %s: %w", fifoPath, err)
+		}
+	}
+
+	return nil
+}
+
+// getSocketOwner returns the UID/GID of a unix socket file.
+// Returns 0, 0, false if the owner cannot be determined.
+func getSocketOwner(socketPath string) (int, int, bool) {
+	if !strings.HasPrefix(socketPath, "unix:") {
+		return 0, 0, false
+	}
+	sockFile := strings.TrimPrefix(socketPath, "unix:")
+	sockFile = strings.TrimPrefix(sockFile, "//")
+
+	info, err := os.Stat(sockFile)
+	if err != nil {
+		return 0, 0, false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return int(stat.Uid), int(stat.Gid), true
 }

--- a/driver.go
+++ b/driver.go
@@ -1983,7 +1983,7 @@ func ensureFifoAccessible(logger hclog.Logger, fifoPath string, podmanClient *ap
 	if ok {
 		if err := os.Chown(fifoPath, uid, gid); err != nil {
 			logger.Warn("failed to chown fifo", "path", fifoPath, "error", err)
-			return os.Chmod(fifoPath, 0666)
+			return err
 		}
 	} else {
 		// Cannot determine socket owner (TCP/HTTP socket or stat failed) — skip.

--- a/driver_test.go
+++ b/driver_test.go
@@ -3089,8 +3089,6 @@ func TestEnsureFifoAccessible(t *testing.T) {
 		expectErr  string
 		// If set, verify fifo ownership matches socket owner
 		verifyChown bool
-		// If set, verify fifo permissions are 0666
-		verifyChmod bool
 		// If true, skip creating a FIFO (for empty/noop cases)
 		skipFifo bool
 		// If true, test requires root
@@ -3172,12 +3170,6 @@ func TestEnsureFifoAccessible(t *testing.T) {
 				fifoStat := info.Sys().(*syscall.Stat_t)
 				must.Eq(t, int(sockStat.Uid), int(fifoStat.Uid), must.Sprint("fifo uid should match socket owner after chown"))
 				must.Eq(t, int(sockStat.Gid), int(fifoStat.Gid), must.Sprint("fifo gid should match socket owner after chown"))
-			}
-
-			if tc.verifyChmod {
-				info, statErr := os.Stat(fifoPath)
-				must.NoError(t, statErr)
-				must.Eq(t, os.FileMode(0666)|os.ModeNamedPipe, info.Mode(), must.Sprint("fifo should be world-writable (0666) after chmod fallback"))
 			}
 		})
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -2988,4 +2989,266 @@ func TestResolveContainerIP(t *testing.T) {
 			must.Eq(t, tc.expectedIP, result)
 		})
 	}
+}
+
+// TestGetSocketOwner verifies getSocketOwner returns the correct uid/gid
+// for unix sockets and false for non-unix or missing paths.
+func TestGetSocketOwner(t *testing.T) {
+	ci.Parallel(t)
+
+	// Use /tmp to avoid macOS socket path length limit (108 chars)
+	dir, err := os.MkdirTemp("/tmp", "sock-test-*")
+	must.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	sockPath := filepath.Join(dir, "t.sock")
+	listener, err := net.Listen("unix", sockPath)
+	must.NoError(t, err)
+	defer listener.Close()
+
+	// Get the actual socket ownership for assertions
+	sockInfo, err := os.Stat(sockPath)
+	must.NoError(t, err)
+	sockStat := sockInfo.Sys().(*syscall.Stat_t)
+
+	testCases := []struct {
+		name      string
+		input     string
+		expectOk  bool
+		expectUid int
+		expectGid int
+	}{
+		{
+			name:      "unix colon prefix",
+			input:     "unix:" + sockPath,
+			expectOk:  true,
+			expectUid: int(sockStat.Uid),
+			expectGid: int(sockStat.Gid),
+		},
+		{
+			name:      "unix double slash prefix",
+			input:     "unix://" + sockPath,
+			expectOk:  true,
+			expectUid: int(sockStat.Uid),
+			expectGid: int(sockStat.Gid),
+		},
+		{
+			name:  "http scheme returns false",
+			input: "http://localhost:8080",
+		},
+		{
+			name:  "tcp scheme returns false",
+			input: "tcp://127.0.0.1:8080",
+		},
+		{
+			name:  "empty string returns false",
+			input: "",
+		},
+		{
+			name:  "non-existent socket returns false",
+			input: "unix:///no/such/path/test.sock",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			uid, gid, ok := getSocketOwner(tc.input)
+			must.Eq(t, tc.expectOk, ok, must.Sprintf("getSocketOwner(%q) ok mismatch", tc.input))
+			if tc.expectOk {
+				must.Eq(t, tc.expectUid, uid, must.Sprintf("getSocketOwner(%q) uid mismatch", tc.input))
+				must.Eq(t, tc.expectGid, gid, must.Sprintf("getSocketOwner(%q) gid mismatch", tc.input))
+			}
+		})
+	}
+}
+
+// TestEnsureFifoAccessible verifies the FIFO accessibility logic for rootless podman.
+func TestEnsureFifoAccessible(t *testing.T) {
+	ci.Parallel(t)
+
+	// Use /tmp to avoid macOS socket path length limit (108 chars)
+	dir, err := os.MkdirTemp("/tmp", "fifo-test-*")
+	must.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// Create a unix socket for tests that need it
+	sockPath := filepath.Join(dir, "t.sock")
+	listener, err := net.Listen("unix", sockPath)
+	must.NoError(t, err)
+	defer listener.Close()
+
+	sockInfo, err := os.Stat(sockPath)
+	must.NoError(t, err)
+	sockStat := sockInfo.Sys().(*syscall.Stat_t)
+
+	testCases := []struct {
+		name       string
+		fifoPath   string
+		rootless   bool
+		socketPath string
+		expectErr  string
+		// If set, verify fifo ownership matches socket owner
+		verifyChown bool
+		// If set, verify fifo permissions are 0666
+		verifyChmod bool
+		// If true, skip creating a FIFO (for empty/noop cases)
+		skipFifo bool
+		// If true, test requires root
+		requireRoot bool
+	}{
+		{
+			name:     "empty path is no-op",
+			fifoPath: "",
+			rootless: true,
+			skipFifo: true,
+		},
+		{
+			name:       "rootful is no-op even with bad path",
+			fifoPath:   "/no/such/fifo",
+			rootless:   false,
+			socketPath: "unix:" + sockPath,
+			skipFifo:   true,
+		},
+		{
+			name:        "chown to socket owner",
+			rootless:    true,
+			socketPath:  "unix:" + sockPath,
+			verifyChown: true,
+		},
+		{
+			name:        "chmod fallback for tcp socket path",
+			rootless:    true,
+			socketPath:  "http://localhost:8080",
+			verifyChmod: true,
+		},
+		{
+			name:       "non-existent fifo returns error",
+			fifoPath:   "/no/such/fifo/path",
+			rootless:   true,
+			socketPath: "http://localhost:8080",
+			expectErr:  "failed to chmod fifo",
+			skipFifo:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.requireRoot && os.Getuid() != 0 {
+				t.Skip("test requires root")
+			}
+
+			logger := testlog.HCLogger(t)
+
+			fifoPath := tc.fifoPath
+			if !tc.skipFifo {
+				fifoPath = filepath.Join(dir, fmt.Sprintf("fifo-%s", tc.name))
+				must.NoError(t, exec.Command("mkfifo", fifoPath).Run())
+				must.NoError(t, os.Chmod(fifoPath, 0600))
+			}
+
+			var client *api.API
+			if tc.socketPath != "" {
+				client = api.NewClient(logger, api.ClientConfig{
+					SocketPath:  tc.socketPath,
+					HttpTimeout: 5 * time.Second,
+				})
+			} else {
+				client = &api.API{}
+			}
+			client.SetRootless(tc.rootless)
+
+			err := ensureFifoAccessible(logger, fifoPath, client)
+
+			if tc.expectErr != "" {
+				must.Error(t, err, must.Sprint("ensureFifoAccessible should have returned an error"))
+				must.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+			must.NoError(t, err, must.Sprint("ensureFifoAccessible should not have returned an error"))
+
+			if tc.verifyChown {
+				info, statErr := os.Stat(fifoPath)
+				must.NoError(t, statErr)
+				fifoStat := info.Sys().(*syscall.Stat_t)
+				must.Eq(t, int(sockStat.Uid), int(fifoStat.Uid), must.Sprint("fifo uid should match socket owner after chown"))
+				must.Eq(t, int(sockStat.Gid), int(fifoStat.Gid), must.Sprint("fifo gid should match socket owner after chown"))
+			}
+
+			if tc.verifyChmod {
+				info, statErr := os.Stat(fifoPath)
+				must.NoError(t, statErr)
+				must.Eq(t, os.FileMode(0666)|os.ModeNamedPipe, info.Mode(), must.Sprint("fifo should be world-writable (0666) after chmod fallback"))
+			}
+		})
+	}
+}
+
+// TestPodmanDriver_LogFifoAccessible is an integration test that verifies
+// the k8s-file log driver path works end-to-end: the driver makes FIFOs
+// accessible to rootless podman before starting the container, and container
+// output is captured correctly through the FIFO.
+func TestPodmanDriver_LogFifoAccessible(t *testing.T) {
+	ci.Parallel(t)
+
+	stdoutMagic := uuid.Generate()
+	stderrMagic := uuid.Generate()
+
+	taskCfg := newTaskConfig("", []string{
+		"sh",
+		"-c",
+		fmt.Sprintf("echo %s; 1>&2 echo %s", stdoutMagic, stderrMagic),
+	})
+	// Use default logging (maps to k8s-file internally), which is the path
+	// that triggers ensureFifoAccessible before container start.
+	taskCfg.Logging.Driver = "nomad"
+
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "logFifoAccess",
+		AllocID:   uuid.Generate(),
+		Resources: createBasicResources(),
+	}
+	must.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+	d := podmanDriverHarness(t, nil)
+	cleanup := d.MkAllocDir(task, true)
+	defer cleanup()
+
+	// Verify the stdout FIFO exists before start
+	_, err := os.Stat(task.StdoutPath)
+	must.NoError(t, err)
+
+	_, _, err = d.StartTask(task)
+	must.NoError(t, err)
+
+	defer func() {
+		_ = d.DestroyTask(task.ID, true)
+	}()
+
+	// After StartTask, verify the FIFO permissions were made accessible.
+	// In rootless mode this will be chowned; in rootful mode it's unchanged.
+	// Either way, the FIFO should still exist and be writable.
+	fifoInfo, err := os.Stat(task.StdoutPath)
+	must.NoError(t, err)
+	fifoMode := fifoInfo.Mode()
+	// The FIFO should be a named pipe
+	must.True(t, fifoMode&os.ModeNamedPipe != 0, must.Sprint("stdout fifo should be a named pipe after StartTask"))
+
+	// Wait for container to finish
+	waitCh, err := d.WaitTask(context.Background(), task.ID)
+	must.NoError(t, err, must.Sprint("WaitTask should not fail"))
+
+	select {
+	case res := <-waitCh:
+		must.Eq(t, 0, res.ExitCode, must.Sprint("container should exit cleanly"))
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Container did not exit in time")
+	}
+
+	// Verify logs were captured through the FIFO — this confirms conmon
+	// could write to the FIFO (the original bug would cause empty logs
+	// or a permission denied startup failure).
+	stdoutLog := readStdoutLog(t, task)
+	must.StrContains(t, stdoutLog, stdoutMagic)
+	must.StrContains(t, stdoutLog, stderrMagic)
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -3091,6 +3091,8 @@ func TestEnsureFifoAccessible(t *testing.T) {
 		verifyChown bool
 		// If true, skip creating a FIFO (for empty/noop cases)
 		skipFifo bool
+		// If true, create a symlink instead of a FIFO (for symlink attack test)
+		createSymlink bool
 		// If true, test requires root
 		requireRoot bool
 	}{
@@ -3127,6 +3129,14 @@ func TestEnsureFifoAccessible(t *testing.T) {
 			skipFifo:   true,
 			// Should not error — just logs and returns nil
 		},
+		{
+			name:          "rejects symlink (TOCTOU protection)",
+			rootless:      true,
+			socketPath:    "unix:" + sockPath,
+			expectErr:     "failed to open fifo",
+			createSymlink: true,
+			skipFifo:      true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -3142,6 +3152,14 @@ func TestEnsureFifoAccessible(t *testing.T) {
 				fifoPath = filepath.Join(dir, fmt.Sprintf("fifo-%s", tc.name))
 				must.NoError(t, exec.Command("mkfifo", fifoPath).Run())
 				must.NoError(t, os.Chmod(fifoPath, 0600))
+			}
+			if tc.createSymlink {
+				// Simulate a symlink swap attack: task replaces FIFO with a
+				// symlink pointing to an arbitrary file (e.g. /etc/shadow).
+				fifoPath = filepath.Join(dir, fmt.Sprintf("fifo-%s", tc.name))
+				target := filepath.Join(dir, "attack-target")
+				must.NoError(t, os.WriteFile(target, []byte("sensitive"), 0600))
+				must.NoError(t, os.Symlink(target, fifoPath))
 			}
 
 			var client *api.API

--- a/driver_test.go
+++ b/driver_test.go
@@ -3262,6 +3262,7 @@ func TestPodmanDriver_LogFifoAccessible(t *testing.T) {
 	must.StrContains(t, stdoutLog, stdoutMagic)
 	must.StrContains(t, stdoutLog, stderrMagic)
 }
+
 // TestPodmanDriver_CustomNetwork validates custom network_mode behavior:
 // successful attachment, non-existent network error, and unreachable socket error.
 func TestPodmanDriver_CustomNetwork(t *testing.T) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -3116,18 +3116,18 @@ func TestEnsureFifoAccessible(t *testing.T) {
 			verifyChown: true,
 		},
 		{
-			name:        "chmod fallback for tcp socket path",
-			rootless:    true,
-			socketPath:  "http://localhost:8080",
-			verifyChmod: true,
+			name:       "noop for tcp socket path",
+			rootless:   true,
+			socketPath: "http://localhost:8080",
+			// TCP socket — cannot determine owner, should noop (no chown, no chmod)
 		},
 		{
-			name:       "non-existent fifo returns error",
+			name:       "noop for non-existent fifo with tcp socket",
 			fifoPath:   "/no/such/fifo/path",
 			rootless:   true,
 			socketPath: "http://localhost:8080",
-			expectErr:  "failed to chmod fifo",
 			skipFifo:   true,
+			// Should not error — just logs and returns nil
 		},
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-podman/issues/189

[**_Issue_**](https://hashicorp.atlassian.net/browse/NMD-544)

When Nomad runs as root and the podman driver is configured to use a rootless podman socket, container log capture fails with `permission denied.`

_**Root cause**_: Nomad's `logmon` creates log FIFOs via `mkfifo(path, 0600)` owned by` root:root`. Podman's `conmon` process (which writes container stdout/stderr into these FIFOs) runs as the non-root podman user and cannot open the FIFO for writing.


**_Before/ After Flow_**

| Step | Before (broken) | After (fixed) |
|------|-----------------|---------------|
| 1. Nomad logmon creates FIFO | `root:root 0600` | `root:root 0600` (unchanged) |
| 2. Driver calls ContainerStart | Immediately | First calls `ensureFifoAccessible()` |
| 3. FIFO ownership/permissions | Unchanged — still `root:root 0600` | Chowned to podman socket owner (e.g. `podmanuser:podmanuser`) |
| 4. Conmon opens FIFO for writing | **EPERM — cannot write** | Succeeds — owns the file |
| 5. Container logs | Empty / container fails to start | Captured correctly |

**_Behaviour_**

Scenario | Action
-- | --
Rootful podman | No-op (conmon runs as root, already has access)
Rootless + unix socket | chown(fifo, socket_uid, socket_gid)
Chown fails (e.g. Nomad not root) | Returns error; warning logged, container start still attempted
TCP/HTTP socket (no file to stat) | No-op; debug logged, container start still attempted
FIFO path empty | No-op



**_Major Changes_**

- `driver.go`: Added `ensureFifoAccessible()` and `getSocketOwner()` helpers; called before ContainerStart when log driver is k8s-file
- `api.go`: Added `GetSocketPath()` getter to expose the configured socket path

**_Why chown?_**

- `chown` changes FIFO ownership to the podman user. This is least-privilege — only the intended user can write, not the entire system. If the socket owner can't be determined (TCP socket), the function is a no-op: it logs a debug message and returns without modifying the FIFO. The caller logs a warning and allows the task to proceed

**Testing**
<details>

Files Used:

1) nomad-rootless.hcl
```
log_level = "DEBUG"

plugin "nomad-driver-podman" {
  config {
    # Point to the rootless podman socket (owned by podmanuser, UID 1001)
    socket_path = "unix:///run/user/1001/podman/podman.sock"

    volumes {
      enabled = true
    }

    # Use default "nomad" log driver (k8s-file) — this triggers the bug
    # Uncommenting the following would AVOID the bug:
    # logging {
    #   driver = "journald"
    # }
  }
}
```

2) redis-rootless.nomad
```
job "redis" {
  datacenters = ["dc1"]
  type        = "service"

  group "cache" {
    network {
      port "redis" { to = 6379 }
    }

    task "redis" {
      driver = "podman"

      config {
        image = "docker.io/library/redis:7-alpine"
        ports = ["redis"]
      }

      resources {
        cpu    = 100
        memory = 128
      }
    }
  }
}
```

**Before Fix:**

```
==> 2026-06-03T15:22:18+05:30: Monitoring evaluation "77d20c20"
    2026-06-03T15:22:18+05:30: Evaluation triggered by job "redis"
    2026-06-03T15:22:19+05:30: Evaluation within deployment: "ba9e8c8e"
    2026-06-03T15:22:19+05:30: Allocation "3439c0f4" created: node "e1b68fea", group "cache"
    2026-06-03T15:22:19+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-06-03T15:22:19+05:30: Evaluation "77d20c20" finished with status "complete"
==> 2026-06-03T15:22:19+05:30: Monitoring deployment "ba9e8c8e"
  ⠇ Deployment "ba9e8c8e" in progress...
    
    2026-06-03T15:23:52+05:30
    ID          = ba9e8c8e
    Job ID      = redis
    Job Version = 0
    Status      = running
    Description = Deployment is running
    
    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    cache       1        3       0        3          2026-06-03T15:32:18+05:30
```

```
2026-06-03T15:22:18.447+0530 [DEBUG] client.alloc_runner.task_runner.task_hook.logmon.nomad: opening fifo: alloc_id=3439c0f4-6c8f-f27b-02a3-8a3d23f17ec5 task=redis @module=logmon path=/tmp/NomadClient1343120992/3439c0f4-6c8f-f27b-02a3-8a3d23f17ec5/alloc/logs/.redis.stderr.fifo timestamp="2026-06-03T15:22:18.447+0530"
  | rpc error: code = Unknown desc = failed to start task, could not start container: cannot start container, status code: 500: {"cause":"exit status 1","message":"conmon failed: exit status 1","response":500}
```

```
prw------- 1 root root 0 Jun  3 15:23 /tmp/NomadClient1343120992/217a17f7-de48-aaee-696e-7c8048b3df61/alloc/logs/.redis.stdout.fifo
prw------- 1 root root 0 Jun  3 15:22 /tmp/NomadClient1343120992/3439c0f4-6c8f-f27b-02a3-8a3d23f17ec5/alloc/logs/.redis.stdout.fifo
prw------- 1 root root 0 Jun  3 15:22 /tmp/NomadClient1343120992/6872aa48-96c1-a6e3-36dd-51f2fea72000/alloc/logs/.redis.stdout.fifo
```

**After Fix:**

```
==> 2026-06-03T15:35:15+05:30: Monitoring evaluation "a871ca59"
    2026-06-03T15:35:15+05:30: Evaluation triggered by job "redis"
    2026-06-03T15:35:16+05:30: Evaluation within deployment: "cd1adcea"
    2026-06-03T15:35:16+05:30: Allocation "81e68250" created: node "5ddbf4ab", group "cache"
    2026-06-03T15:35:16+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-06-03T15:35:16+05:30: Evaluation "a871ca59" finished with status "complete"
==> 2026-06-03T15:35:16+05:30: Monitoring deployment "cd1adcea"
  ✓ Deployment "cd1adcea" successful
    
    2026-06-03T15:35:27+05:30
    ID          = cd1adcea
    Job ID      = redis
    Job Version = 0
    Status      = successful
    Description = Deployment completed successfully
    
    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    cache       1        1       1        0          2026-06-03T15:45:25+05:30
```

```
Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
81e68250  5ddbf4ab  cache       0        run      running  23s ago  13s ago
```
```
2026-06-03T15:35:15.788+0530 [DEBUG] client.alloc_runner.task_runner.task_hook.logmon.nomad: opening fifo: alloc_id=81e68250-3ae5-fdba-647b-689241d4a734 task=redis @module=logmon path=/tmp/NomadClient3574866466/81e68250-3ae5-fdba-647b-689241d4a734/alloc/logs/.redis.stdout.fifo timestamp="2026-06-03T15:35:15.788+0530"
```
```
prw------- 1 podmanuser podmanuser 0 Jun  3 15:35 /tmp/NomadClient3574866466/81e68250-3ae5-fdba-647b-689241d4a734/alloc/logs/.redis.stdout.fifo
```

</details>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

