### PR TITLE
Fix: userns=auto resulting in no UID/GID mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 BUG FIXES:
 * api: Fixed file descriptor leak when getting logs from the task [[GH-508](https://github.com/hashicorp/nomad-driver-podman/pull/508)]
 * driver: Fixed static IP configuration (`static_ips`, `ipv4_address`, `ipv6_address`, `static_mac`) being silently ignored, corrected related per-network map handling and `driverNet.IP` resolution for service discovery. [[GH-507](https://github.com/hashicorp/nomad-driver-podman/pull/507)]
+* driver: Fixed `userns=auto` being ignored when no sub-options (e.g. size) are specified [[GH-511](https://github.com/hashicorp/nomad-driver-podman/pull/511)]
 
 ## 0.6.4 (December 10, 2025)
 

--- a/README.md
+++ b/README.md
@@ -549,6 +549,18 @@ config {
 
 ```hcl
 config {
+  userns = "auto"
+}
+```
+
+```hcl
+config {
+  userns = "auto:size=65536"
+}
+```
+
+```hcl
+config {
   userns = "keep-id:uid=200,gid=210"
 }
 ```

--- a/api/container_logs.go
+++ b/api/container_logs.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/network_exists.go
+++ b/api/network_exists.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/network_exists_test.go
+++ b/api/network_exists_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/driver.go
+++ b/driver.go
@@ -1877,7 +1877,7 @@ func parseUserNSConfig(userNSConfig string) (api.Namespace, *api.IDMappingOption
 	modeWithConfig := strings.SplitN(userNSConfig, ":", 2)
 	mode := api.NamespaceMode(modeWithConfig[0])
 
-	config := ""
+	var config string
 	if len(modeWithConfig) == 2 {
 		config = modeWithConfig[1]
 	}

--- a/driver.go
+++ b/driver.go
@@ -739,7 +739,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	// Populate --userns mode only if configured
 	if podmanTaskConfig.UserNS != "" {
 		userns, mappings, userNSerr := parseUserNSConfig(podmanTaskConfig.UserNS)
-		if err != nil {
+		if userNSerr != nil {
 			return nil, nil, fmt.Errorf("failed to parse userns configuration: %w", userNSerr)
 		}
 		createOpts.ContainerSecurityConfig.UserNS = userns
@@ -1860,29 +1860,32 @@ func parseUserNSConfig(userNSConfig string) (api.Namespace, *api.IDMappingOption
 	modeWithConfig := strings.SplitN(userNSConfig, ":", 2)
 	mode := api.NamespaceMode(modeWithConfig[0])
 
-	if len(modeWithConfig) == 1 {
-		// if there's no additional configuration, we can bail out early
-		return api.Namespace{NSMode: mode}, nil, nil
+	config := ""
+	if len(modeWithConfig) == 2 {
+		config = modeWithConfig[1]
 	}
 
-	config := modeWithConfig[1]
 	ns := api.Namespace{NSMode: mode, Value: config}
 
 	switch mode {
 	case "", "host":
 		return ns, nil, nil
 	case "auto":
-		autoOpts := strings.Split(config, ",")
 		mappings := &api.IDMappingOptions{
 			UIDMap:         []api.IDMap{},
 			GIDMap:         []api.IDMap{},
 			AutoUserNs:     true,
 			AutoUserNsOpts: api.AutoUserNsOptions{},
 		}
+		if config == "" {
+			return ns, mappings, nil
+		}
+
+		autoOpts := strings.Split(config, ",")
 		for _, opt := range autoOpts {
-			kv := strings.Split(opt, "=")
+			kv := strings.SplitN(opt, "=", 2)
 			if len(kv) != 2 {
-				return ns, nil, fmt.Errorf("invalid userns configuration: %q", kv)
+				return ns, nil, fmt.Errorf("invalid userns configuration: %q", opt)
 			}
 			switch kv[0] {
 			case "gidmapping":
@@ -1897,7 +1900,7 @@ func parseUserNSConfig(userNSConfig string) (api.Namespace, *api.IDMappingOption
 			case "size":
 				sz, err := strconv.ParseUint(kv[1], 10, 32)
 				if err != nil {
-					return ns, nil, err
+					return ns, nil, fmt.Errorf("invalid userns size %q: %w", kv[1], err)
 				}
 				mappings.AutoUserNsOpts.Size = uint32(sz)
 			case "uidmapping":
@@ -1909,6 +1912,8 @@ func parseUserNSConfig(userNSConfig string) (api.Namespace, *api.IDMappingOption
 				mappings.UIDMap = append(mappings.UIDMap, *idMap)
 				mappings.AutoUserNsOpts.AdditionalUIDMappings = append(
 					mappings.AutoUserNsOpts.AdditionalUIDMappings, *idMap)
+			default:
+				return ns, nil, fmt.Errorf("invalid userns auto option %q", kv[0])
 			}
 		}
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -2904,28 +2904,6 @@ func TestUserNSConfigParsing(t *testing.T) {
 
 }
 
-func TestPodmanDriver_StartTask_InvalidUserNS_ReturnsParseError(t *testing.T) {
-	ci.Parallel(t)
-
-	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
-	taskCfg.UserNS = "auto:unknown=1"
-
-	task := &drivers.TaskConfig{
-		ID:        uuid.Generate(),
-		Name:      "invalid-userns",
-		AllocID:   uuid.Generate(),
-		Resources: createBasicResources(),
-	}
-	must.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
-
-	d := podmanDriverHarness(t, nil)
-	cleanup := d.MkAllocDir(task, true)
-	defer cleanup()
-
-	_, _, err := d.StartTask(task)
-	must.ErrorContains(t, err, "failed to parse userns configuration")
-}
-
 func TestResolveContainerIP(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/driver_test.go
+++ b/driver_test.go
@@ -2841,6 +2841,20 @@ func TestUserNSConfigParsing(t *testing.T) {
 			expectNamespace: api.Namespace{
 				NSMode: "auto",
 			},
+			expectMapping: &api.IDMappingOptions{
+				UIDMap:         []api.IDMap{},
+				GIDMap:         []api.IDMap{},
+				AutoUserNs:     true,
+				AutoUserNsOpts: api.AutoUserNsOptions{},
+			},
+		},
+		{
+			input:     "made-up-mode",
+			expectErr: `unknown userns mode "made-up-mode"`,
+		},
+		{
+			input:     "auto:unknown=1",
+			expectErr: `invalid userns auto option "unknown"`,
 		},
 		{
 			input: "auto:uidmapping=33:1001:1,gidmapping=34:1002:2,size=3",
@@ -2887,6 +2901,28 @@ func TestUserNSConfigParsing(t *testing.T) {
 		}
 	}
 
+}
+
+func TestPodmanDriver_StartTask_InvalidUserNS_ReturnsParseError(t *testing.T) {
+	ci.Parallel(t)
+
+	taskCfg := newTaskConfig("", busyboxLongRunningCmd)
+	taskCfg.UserNS = "auto:unknown=1"
+
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "invalid-userns",
+		AllocID:   uuid.Generate(),
+		Resources: createBasicResources(),
+	}
+	must.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+	d := podmanDriverHarness(t, nil)
+	cleanup := d.MkAllocDir(task, true)
+	defer cleanup()
+
+	_, _, err := d.StartTask(task)
+	must.ErrorContains(t, err, "failed to parse userns configuration")
 }
 
 func TestResolveContainerIP(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-podman/issues/503
[JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1415)

**_Summary_**

Setting `userns = "auto"` in a rootful Podman task configuration silently fails to apply user namespace isolation. The container runs as actual root on the host `(uid_map: 0 0 4294967295)`, defeating the purpose of auto user namespace isolation.

However, `userns = "auto:size=65536"` works correctly — adding any option after the colon triggers proper behavior. It took a different code path.

**_Root Cause_**

**1) Early return skips mapping initialization for plain `auto`**

```
if len(modeWithConfig) == 1 {
    return api.Namespace{NSMode: mode}, nil, nil  // ← nil mappings!
}
```
When `userns="auto"` has no colon, the parser returns early with nil IDMappings. The case "auto" branch that sets AutoUserNs: true is never reached. Podman receives the auto mode flag but no mapping instructions, so it does nothing.

**2) Error variable mismatch swallows parse failures**
```
userns, mappings, userNSerr := parseUserNSConfig(...)
if err != nil {  // ← wrong variable! should be userNSerr
```

**_Fix_**

Ensure that even bare `userns = "auto"` (without sub-options) returns a properly initialized `&IDMappingOptions{AutoUserNs: true, UIDMap: []IDMap{}, GIDMap: []IDMap{}}`. The mappings struct is now constructed before the sub-options check, so both `"auto"` and `"auto:size=N,..."` share the same initialization path.

**_Before/After Flow_**


Scenario |   | IDMappings sent to Podman | Container uid_map
-- | -- | -- | --
userns = "auto" (rootful) | Before | nil (omitted from JSON) | 0 0 4294967295 (no isolation)
  | After | &{AutoUserNs: true, UIDMap: [], GIDMap: []} | 0 300000 1024 (isolated)
userns = "auto:size=65536" | Before | &{AutoUserNs: true, Size: 65536} | 0 300000 65536 ✓
  | After | &{AutoUserNs: true, Size: 65536} | 0 300000 65536 ✓
userns = "auto:invalid=x" (error handling) | Before | (error swallowed silently) | Container starts without isolation
  | After | (error returned to caller) | Task fails with "failed to parse userns configuration" ✓

**_Testing:_**
<details>

**1) Previous Flow:**  
```
2026-06-05T12:54:21.609665941+05:30 stdout F          0          0 4294967295
```
UID 0 in the container maps to UID 0 on the host, no user namespace isolation at all. The container is running as actual root. 

**2) Current Flow**
```
2026-06-05T12:59:44.920613444+05:30 stdout F          0     300000       1024
```

UID 0 in the container is actually UID 300000 on the host. The container only has access to 1024 UIDs (300000–301023). Proper isolation. Even if a process escapes the container, it's just an unprivileged user (300000) on the host — not root.

`userns = "auto"` now properly tells Podman to allocate automatic UID/GID mappings from the configured subuid/subgid ranges, providing user namespace isolation.

</details>


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

