### PR TITLE
fix: eliminate transitive docker dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * config: Adds support for plugin configuration `networking.default_rootless_mode` to override the default networking mode when run rootlessly. [[GH-495](https://github.com/hashicorp/nomad-driver-podman/pull/495)]
 * config: Support custom Podman network names for static IP/MAC options via `network_mode`. [[GH-509](https://github.com/hashicorp/nomad-driver-podman/pull/509)]
+* build: Eliminated transitive dependency on Docker packages via `hclutils`.[[GH-512](https://github.com/hashicorp/nomad-driver-podman/pull/512)]
 
 BUG FIXES:
 * api: Fixed file descriptor leak when getting logs from the task [[GH-508](https://github.com/hashicorp/nomad-driver-podman/pull/508)]

--- a/api/network_exists.go
+++ b/api/network_exists.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/network_exists_test.go
+++ b/api/network_exists_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/config.go
+++ b/config.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
+	"github.com/hashicorp/nomad-driver-podman/internal/hclcompat"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 )
 
@@ -180,8 +180,8 @@ type NetworkingConfig struct {
 // LoggingConfig is the tasks logging configuration
 // keep in sync with `LoggingConfig`
 type TaskLoggingConfig struct {
-	Driver  string             `codec:"driver"`
-	Options hclutils.MapStrStr `codec:"options"`
+	Driver  string              `codec:"driver"`
+	Options hclcompat.MapStrStr `codec:"options"`
 }
 
 // Empty returns true if the logging configuration is not set.
@@ -253,7 +253,7 @@ type TaskConfig struct {
 	StaticMAC         string             `codec:"static_mac"`
 	InitPath          string             `codec:"init_path"`
 	Logging           TaskLoggingConfig  `codec:"logging"`
-	Labels            hclutils.MapStrStr `codec:"labels"`
+	Labels            hclcompat.MapStrStr `codec:"labels"`
 	MemoryReservation string             `codec:"memory_reservation"`
 	MemorySwap        string             `codec:"memory_swap"`
 	NetworkMode       string             `codec:"network_mode"`
@@ -262,10 +262,10 @@ type TaskConfig struct {
 	CPUCFSPeriod      uint64             `codec:"cpu_cfs_period"`
 	MemorySwappiness  int64              `codec:"memory_swappiness"`
 	PidsLimit         int64              `codec:"pids_limit"`
-	PortMap           hclutils.MapStrInt `codec:"port_map"`
+	PortMap           hclcompat.MapStrInt `codec:"port_map"`
 	Socket            string             `codec:"socket"`
-	Sysctl            hclutils.MapStrStr `codec:"sysctl"`
-	Ulimit            hclutils.MapStrStr `codec:"ulimit"`
+	Sysctl            hclcompat.MapStrStr `codec:"sysctl"`
+	Ulimit            hclcompat.MapStrStr `codec:"ulimit"`
 	CPUHardLimit      bool               `codec:"cpu_hard_limit"`
 	Init              bool               `codec:"init"`
 	Tty               bool               `codec:"tty"`

--- a/config.go
+++ b/config.go
@@ -230,49 +230,49 @@ func (c *PluginConfig) LogWarnings(logger hclog.Logger) {
 
 // TaskConfig is the driver configuration of a task within a job
 type TaskConfig struct {
-	ApparmorProfile   string             `codec:"apparmor_profile"`
-	Args              []string           `codec:"args"`
-	Auth              TaskAuthConfig     `codec:"auth"`
-	AuthSoftFail      bool               `codec:"auth_soft_fail"`
-	Ports             []string           `codec:"ports"`
-	Tmpfs             []string           `codec:"tmpfs"`
-	Volumes           []string           `codec:"volumes"`
-	CapAdd            []string           `codec:"cap_add"`
-	CapDrop           []string           `codec:"cap_drop"`
-	SelinuxOpts       []string           `codec:"selinux_opts"`
-	Command           string             `codec:"command"`
-	Devices           []string           `codec:"devices"`
-	Entrypoint        any                `codec:"entrypoint"` // any for compat
-	WorkingDir        string             `codec:"working_dir"`
-	Hostname          string             `codec:"hostname"`
-	Image             string             `codec:"image"`
-	ImagePullTimeout  string             `codec:"image_pull_timeout"`
-	IPv4Address       string             `codec:"ipv4_address"`
-	IPv6Address       string             `codec:"ipv6_address"`
-	StaticIPs         []string           `codec:"static_ips"`
-	StaticMAC         string             `codec:"static_mac"`
-	InitPath          string             `codec:"init_path"`
-	Logging           TaskLoggingConfig  `codec:"logging"`
+	ApparmorProfile   string              `codec:"apparmor_profile"`
+	Args              []string            `codec:"args"`
+	Auth              TaskAuthConfig      `codec:"auth"`
+	AuthSoftFail      bool                `codec:"auth_soft_fail"`
+	Ports             []string            `codec:"ports"`
+	Tmpfs             []string            `codec:"tmpfs"`
+	Volumes           []string            `codec:"volumes"`
+	CapAdd            []string            `codec:"cap_add"`
+	CapDrop           []string            `codec:"cap_drop"`
+	SelinuxOpts       []string            `codec:"selinux_opts"`
+	Command           string              `codec:"command"`
+	Devices           []string            `codec:"devices"`
+	Entrypoint        any                 `codec:"entrypoint"` // any for compat
+	WorkingDir        string              `codec:"working_dir"`
+	Hostname          string              `codec:"hostname"`
+	Image             string              `codec:"image"`
+	ImagePullTimeout  string              `codec:"image_pull_timeout"`
+	IPv4Address       string              `codec:"ipv4_address"`
+	IPv6Address       string              `codec:"ipv6_address"`
+	StaticIPs         []string            `codec:"static_ips"`
+	StaticMAC         string              `codec:"static_mac"`
+	InitPath          string              `codec:"init_path"`
+	Logging           TaskLoggingConfig   `codec:"logging"`
 	Labels            hclcompat.MapStrStr `codec:"labels"`
-	MemoryReservation string             `codec:"memory_reservation"`
-	MemorySwap        string             `codec:"memory_swap"`
-	NetworkMode       string             `codec:"network_mode"`
-	OOMScoreAdj       int16              `codec:"oom_score_adj"`
-	ExtraHosts        []string           `codec:"extra_hosts"`
-	CPUCFSPeriod      uint64             `codec:"cpu_cfs_period"`
-	MemorySwappiness  int64              `codec:"memory_swappiness"`
-	PidsLimit         int64              `codec:"pids_limit"`
+	MemoryReservation string              `codec:"memory_reservation"`
+	MemorySwap        string              `codec:"memory_swap"`
+	NetworkMode       string              `codec:"network_mode"`
+	OOMScoreAdj       int16               `codec:"oom_score_adj"`
+	ExtraHosts        []string            `codec:"extra_hosts"`
+	CPUCFSPeriod      uint64              `codec:"cpu_cfs_period"`
+	MemorySwappiness  int64               `codec:"memory_swappiness"`
+	PidsLimit         int64               `codec:"pids_limit"`
 	PortMap           hclcompat.MapStrInt `codec:"port_map"`
-	Socket            string             `codec:"socket"`
+	Socket            string              `codec:"socket"`
 	Sysctl            hclcompat.MapStrStr `codec:"sysctl"`
 	Ulimit            hclcompat.MapStrStr `codec:"ulimit"`
-	CPUHardLimit      bool               `codec:"cpu_hard_limit"`
-	Init              bool               `codec:"init"`
-	Tty               bool               `codec:"tty"`
-	ForcePull         bool               `codec:"force_pull"`
-	Privileged        bool               `codec:"privileged"`
-	ReadOnlyRootfs    bool               `codec:"readonly_rootfs"`
-	UserNS            string             `codec:"userns"`
-	ShmSize           string             `codec:"shm_size"`
-	SecurityOpt       []string           `codec:"security_opt"`
+	CPUHardLimit      bool                `codec:"cpu_hard_limit"`
+	Init              bool                `codec:"init"`
+	Tty               bool                `codec:"tty"`
+	ForcePull         bool                `codec:"force_pull"`
+	Privileged        bool                `codec:"privileged"`
+	ReadOnlyRootfs    bool                `codec:"readonly_rootfs"`
+	UserNS            string              `codec:"userns"`
+	ShmSize           string              `codec:"shm_size"`
+	SecurityOpt       []string            `codec:"security_opt"`
 }

--- a/config_test.go
+++ b/config_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad-driver-podman/ci"
-	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/shoenig/test/must"
 )
 
 func TestConfig_Ports(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	expectedPorts := []string{"redis"}
 	validHCL := `
   config {
@@ -31,7 +30,7 @@ func TestConfig_Ports(t *testing.T) {
 func TestConfig_Logging(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	expectedDriver := "journald"
 	expectedTag := "redis"
 	validHCL := `
@@ -57,7 +56,7 @@ func TestConfig_Logging(t *testing.T) {
 func TestConfig_Labels(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	validHCL := `
   config {
 	  image = "docker://redis"
@@ -75,7 +74,7 @@ func TestConfig_Labels(t *testing.T) {
 func TestConfig_ForcePull(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	validHCL := `
   config {
 		image = "docker://redis"
@@ -91,7 +90,7 @@ func TestConfig_ForcePull(t *testing.T) {
 func TestConfig_CPUHardLimit(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	validHCL := `
   config {
 		image = "docker://redis"
@@ -109,7 +108,7 @@ func TestConfig_CPUHardLimit(t *testing.T) {
 func TestConfig_ImagePullTimeout(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	validHCL := `
   config {
 		image = "docker://redis"
@@ -125,7 +124,7 @@ func TestConfig_ImagePullTimeout(t *testing.T) {
 func TestConfig_ExtraHosts(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	validHCL := `
 		config {
 		image = "docker://redis"
@@ -141,7 +140,7 @@ func TestConfig_ExtraHosts(t *testing.T) {
 func TestConfig_PodmanSocketDefaultIfNotGiven(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	validHCL := `
 	config {
 		image = "docker://redis"
@@ -156,7 +155,7 @@ func TestConfig_PodmanSocketDefaultIfNotGiven(t *testing.T) {
 func TestConfig_PodmanOOMScoreAdj(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(taskConfigSpec)
+	parser := newConfigParser(taskConfigSpec)
 	validHCL := `
 	config {
 		image = "docker://redis"
@@ -172,7 +171,7 @@ func TestConfig_PodmanOOMScoreAdj(t *testing.T) {
 func TestPluginConfig_Parsing(t *testing.T) {
 	ci.Parallel(t)
 
-	parser := hclutils.NewConfigParser(configSpec)
+	parser := newConfigParser(configSpec)
 	validHCL := `config {
 
   socket {

--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,18 @@ require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/containers/common v0.64.2
 	github.com/containers/image/v5 v5.36.2
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/hashicorp/go-hclog v1.6.3
+	github.com/hashicorp/go-msgpack/v2 v2.1.5
 	github.com/hashicorp/go-version v1.9.0
+	github.com/hashicorp/hcl v1.0.1-vault-7
+	github.com/hashicorp/hcl/v2 v2.23.0
 	github.com/hashicorp/nomad v1.11.3
 	github.com/hashicorp/nomad/api v0.0.0-20251209201056-5b76eb053561
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/shoenig/test v1.13.2
+	github.com/zclconf/go-cty v1.18.0
 	golang.org/x/sync v0.20.0
 )
 
@@ -58,7 +63,6 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gojuno/minimock/v3 v3.4.5 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -78,7 +82,6 @@ require (
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.20 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
-	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
@@ -94,8 +97,6 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
-	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
 	github.com/hashicorp/memberlist v0.5.4 // indirect
 	github.com/hashicorp/raft v1.7.3 // indirect
 	github.com/hashicorp/raft-autopilot v0.3.0 // indirect
@@ -104,7 +105,6 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hpcloud/tail v1.0.1-0.20170814160653-37f427138745 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
-	github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987 // indirect
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
@@ -155,7 +155,6 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	github.com/zclconf/go-cty v1.18.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20250808145144-a408d31f581a // indirect
 	golang.org/x/mod v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
-github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
@@ -69,8 +67,6 @@ github.com/container-storage-interface/spec v1.12.0 h1:zrFOEqpR5AghNaaDG4qyedwPB
 github.com/container-storage-interface/spec v1.12.0/go.mod h1:txsm+MA2B2WDa5kW69jNbqPnvTtfvZma7T/zsAZ9qX8=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
-github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
-github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containers/common v0.64.2 h1:1xepE7QwQggUXxmyQ1Dbh6Cn0yd7ktk14sN3McSWf5I=
@@ -189,8 +185,6 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDa
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/hashicorp/cli v1.1.7 h1:/fZJ+hNdwfTSfsxMBa9WWMlfjUZbX8/LnUxgAd7lCVU=
 github.com/hashicorp/cli v1.1.7/go.mod h1:e6Mfpga9OCT1vqzFuoGZiiF/KaG9CbUfO5s3ghU3YgU=
-github.com/hashicorp/consul-template v0.41.4 h1:JnmGtDk/J/kFbESGDosIy0x53+PtHGeWQKKNHt4hYKM=
-github.com/hashicorp/consul-template v0.41.4/go.mod h1:70a9elDlGys7j3ixDEO+/EvxymLzkCTYsILNVyJGXE4=
 github.com/hashicorp/consul/api v1.33.4 h1:AJkZp6qzgAYcMIU0+CjJ0Rb7+byfh0dazFK/gzlOcJk=
 github.com/hashicorp/consul/api v1.33.4/go.mod h1:BkH3WEUzsnWvJJaHoDqKqoe2Q2EIixx7Gjj6MTwYnOA=
 github.com/hashicorp/consul/sdk v0.17.2 h1:sC0jgNhJkZX3wo1DCrkG12r+1JlZQpWvk3AoL3yZE4Q=
@@ -281,8 +275,6 @@ github.com/hpcloud/tail v1.0.1-0.20170814160653-37f427138745 h1:8as8OQ+RF1QrsHvW
 github.com/hpcloud/tail v1.0.1-0.20170814160653-37f427138745/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987 h1:pf7+hef676aOjZ9XcvEw5qhdTPPaFVfavOQS+IntVOY=
-github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f h1:E87tDTVS5W65euzixn7clSzK66puSt1H4I5SC0EmHH4=
 github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f/go.mod h1:3J2qVK16Lq8V+wfiL2lPeDZ7UWMxk5LemerHa1p6N00=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
@@ -346,8 +338,6 @@ github.com/mitchellh/pointerstructure v1.2.1 h1:ZhBBeX8tSlRpu/FFhXH4RC4OJzFlqsQh
 github.com/mitchellh/pointerstructure v1.2.1/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
-github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/capability v0.4.0 h1:4D4mI6KlNtWMCM1Z/K0i7RV1FkX+DBDHKVJpCndZoHk=
@@ -360,8 +350,6 @@ github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7z
 github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
 github.com/moby/sys/user v0.4.0 h1:jhcMKit7SA80hivmFJcbB1vqmw//wU61Zdui2eQXuMs=
 github.com/moby/sys/user v0.4.0/go.mod h1:bG+tYYYJgaMtRKgEmuueC0hJEAZWwtIbZTB+85uoHjs=
-github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
-github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -369,8 +357,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
-github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/internal/hclcompat/types.go
+++ b/internal/hclcompat/types.go
@@ -1,0 +1,58 @@
+// Copyright IBM Corp. 2019, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package hclcompat provides HCL compatibility types that were previously
+// imported from github.com/hashicorp/nomad/helper/pluginutils/hclutils.
+// These types are replicated here to eliminate the transitive dependency
+// on Docker packages that came through that import path.
+package hclcompat
+
+import (
+	"github.com/hashicorp/go-msgpack/v2/codec"
+)
+
+// MapStrInt is a wrapper for map[string]int that handles
+// deserialization from different HCL2 JSON representations
+// that were supported since Nomad 0.8.
+type MapStrInt map[string]int
+
+func (s *MapStrInt) CodecEncodeSelf(enc *codec.Encoder) {
+	v := []map[string]int{*s}
+	enc.MustEncode(v)
+}
+
+func (s *MapStrInt) CodecDecodeSelf(dec *codec.Decoder) {
+	ms := []map[string]int{}
+	dec.MustDecode(&ms)
+
+	r := map[string]int{}
+	for _, m := range ms {
+		for k, v := range m {
+			r[k] = v
+		}
+	}
+	*s = r
+}
+
+// MapStrStr is a wrapper for map[string]string that handles
+// deserialization from different HCL2 JSON representations
+// that were supported since Nomad 0.8.
+type MapStrStr map[string]string
+
+func (s *MapStrStr) CodecEncodeSelf(enc *codec.Encoder) {
+	v := []map[string]string{*s}
+	enc.MustEncode(v)
+}
+
+func (s *MapStrStr) CodecDecodeSelf(dec *codec.Decoder) {
+	ms := []map[string]string{}
+	dec.MustDecode(&ms)
+
+	r := map[string]string{}
+	for _, m := range ms {
+		for k, v := range m {
+			r[k] = v
+		}
+	}
+	*s = r
+}

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -1,0 +1,175 @@
+// Copyright IBM Corp. 2019, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/hashicorp/go-msgpack/v2/codec"
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/ast"
+	hcl2 "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcldec"
+	hjson "github.com/hashicorp/hcl/v2/json"
+	"github.com/hashicorp/nomad/helper/pluginutils/hclspecutils"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/plugins/shared/hclspec"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+// hclParser is a test helper for parsing driver TaskConfig from HCL.
+// This replaces the import of github.com/hashicorp/nomad/helper/pluginutils/hclutils
+// to eliminate the transitive Docker dependency.
+type hclParser struct {
+	spec *hclspec.Spec
+	vars map[string]cty.Value
+}
+
+// newConfigParser returns a helper for parsing driver TaskConfig.
+// Parser is an immutable object that can be used in multiple tests.
+func newConfigParser(spec *hclspec.Spec) *hclParser {
+	return &hclParser{
+		spec: spec,
+	}
+}
+
+// ParseHCL parses the HCL config string and decodes it into the out parameter.
+// out parameter should be a pointer to a driver-specific TaskConfig.
+func (p *hclParser) ParseHCL(t *testing.T, configStr string, out interface{}) {
+	t.Helper()
+	config := hclConfigToInterface(t, configStr)
+	p.parse(t, config, out)
+}
+
+func (p *hclParser) parse(t *testing.T, config, out interface{}) {
+	t.Helper()
+
+	decSpec, diags := hclspecutils.Convert(p.spec)
+	if diags.HasErrors() {
+		t.Fatalf("failed to convert spec: %v", diags.Error())
+	}
+
+	ctyValue, diag, errs := parseHclInterface(config, decSpec, p.vars)
+	if len(errs) > 0 {
+		t.Error("unexpected errors parsing config")
+		for _, err := range errs {
+			t.Errorf("  * %v", err)
+		}
+		t.FailNow()
+	}
+	if diag.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %v", diag.Error())
+	}
+
+	// encode
+	dtc := &drivers.TaskConfig{}
+	if err := dtc.EncodeDriverConfig(ctyValue); err != nil {
+		t.Fatalf("failed to encode driver config: %v", err)
+	}
+
+	// decode
+	if err := dtc.DecodeDriverConfig(out); err != nil {
+		t.Fatalf("failed to decode driver config: %v", err)
+	}
+}
+
+// hclConfigToInterface parses an HCL config string into a Go interface.
+func hclConfigToInterface(t *testing.T, config string) interface{} {
+	t.Helper()
+
+	root, err := hcl.Parse(config)
+	if err != nil {
+		t.Fatalf("failed to hcl parse the config: %v", err)
+	}
+
+	list, ok := root.Node.(*ast.ObjectList)
+	if !ok {
+		t.Fatalf("root should be an object")
+	}
+
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, list.Items[0]); err != nil {
+		t.Fatalf("failed to decode object: %v", err)
+	}
+
+	var m2 map[string]interface{}
+	if err := mapstructure.WeakDecode(m, &m2); err != nil {
+		t.Fatalf("failed to weak decode object: %v", err)
+	}
+
+	return m2["config"]
+}
+
+// parseHclInterface converts an interface value representing an HCL2 body
+// and returns the interpolated cty.Value.
+func parseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Value) (cty.Value, hcl2.Diagnostics, []error) {
+	evalCtx := &hcl2.EvalContext{
+		Variables: vars,
+		Functions: getStdlibFuncs(),
+	}
+
+	var buf bytes.Buffer
+	enc := codec.NewEncoder(&buf, structs.JsonHandle)
+	err := enc.Encode(val)
+	if err != nil {
+		errorMessage := fmt.Sprintf("Label encoding failed: %v", err)
+		return cty.NilVal,
+			hcl2.Diagnostics([]*hcl2.Diagnostic{{
+				Severity: hcl2.DiagError,
+				Summary:  "Failed to encode label value",
+				Detail:   errorMessage,
+			}}),
+			[]error{errors.New(errorMessage)}
+	}
+
+	hclFile, diag := hjson.Parse(buf.Bytes(), "")
+	if diag.HasErrors() {
+		return cty.NilVal, diag, formattedDiagnosticErrors(diag)
+	}
+
+	value, decDiag := hcldec.Decode(hclFile.Body, spec, evalCtx)
+	diag = diag.Extend(decDiag)
+	if diag.HasErrors() {
+		return cty.NilVal, diag, formattedDiagnosticErrors(diag)
+	}
+
+	return value, diag, nil
+}
+
+func formattedDiagnosticErrors(diag hcl2.Diagnostics) []error {
+	var errs []error
+	for _, d := range diag {
+		if d.Severity == hcl2.DiagError {
+			errs = append(errs, fmt.Errorf("%s: %s", d.Summary, d.Detail))
+		}
+	}
+	return errs
+}
+
+func getStdlibFuncs() map[string]function.Function {
+	return map[string]function.Function{
+		"abs":        stdlib.AbsoluteFunc,
+		"coalesce":   stdlib.CoalesceFunc,
+		"concat":     stdlib.ConcatFunc,
+		"hasindex":   stdlib.HasIndexFunc,
+		"int":        stdlib.IntFunc,
+		"jsondecode": stdlib.JSONDecodeFunc,
+		"jsonencode": stdlib.JSONEncodeFunc,
+		"length":     stdlib.LengthFunc,
+		"lower":      stdlib.LowerFunc,
+		"max":        stdlib.MaxFunc,
+		"min":        stdlib.MinFunc,
+		"reverse":    stdlib.ReverseFunc,
+		"strlen":     stdlib.StrlenFunc,
+		"substr":     stdlib.SubstrFunc,
+		"upper":      stdlib.UpperFunc,
+	}
+}


### PR DESCRIPTION
Fixes:https://github.com/hashicorp/nomad-driver-podman/issues/249

**_[Issue](https://hashicorp.atlassian.net/browse/NMD-1440)_**

The nomad-driver-podman project carries transitive dependencies on Docker packages (docker/distribution, docker/docker, etc.) through an unnecessary import chain:

```
nomad-driver-podman
  → github.com/hashicorp/nomad/helper/pluginutils/hclutils
    → hclutils/util_test.go imports github.com/hashicorp/nomad/drivers/docker
      → github.com/docker/docker/registry
        → github.com/docker/distribution
```

A Podman driver has no business depending on Docker libraries. This results in:

- Spurious Dependabot security PRs (e.g., #243) for code this project never executes
- Unnecessary entries in go.mod/go.sum for packages that only exist because a test file in Nomad's `hclutils` uses Docker's `TaskConfig` as a test fixture

**_Root Cause_**

The `hclutils` package in Nomad contains production code (types, parsing utilities) and a test file (util_test.go) that imports `nomad/drivers/docker` for test fixtures. When nomad-driver-podman imports `hclutils`, Go's module resolution follows the test dependencies, pulling the entire Docker dependency tree into the module graph.

The production code in `hclutils` itself has zero Docker imports — the dependency is entirely through test code.

**_Fix_**

Replace the `hclutils` import with locally-inlined equivalents:

- `types.go` — `MapStrStr` and `MapStrInt` with their codec encode/decode methods (production code, used by `config.go`)
- `testutil_test.go `— `newConfigParser` and HCL parsing helpers (test-only, excluded from the binary via `_test.go` suffix)


**_Before/After_**
```
# BEFORE: go mod why github.com/docker/distribution
github.com/hashicorp/nomad-driver-podman
github.com/hashicorp/nomad/helper/pluginutils/hclutils        ← unnecessary
github.com/hashicorp/nomad/helper/pluginutils/hclutils.test   ← test dep
github.com/hashicorp/nomad/drivers/docker                     ← Docker!
github.com/docker/docker/registry
github.com/docker/distribution

# AFTER: go mod why github.com/docker/distribution
github.com/hashicorp/nomad-driver-podman
github.com/containers/image/v5/docker                         ← legitimate
github.com/containers/image/v5/pkg/docker/config
github.com/docker/docker/registry
github.com/docker/distribution
```
The `hclutils` path is completely eliminated. Docker packages remain only through containers/image/v5, which legitimately needs them for OCI registry interaction (image pulling).

**_Verification_**
<details>

``` 
go build ./...                        # ✓ compiles
go test -run "TestConfig" ./...       # ✓ all 10 config tests pass
go vet ./...                          # ✓ no issues
go mod graph | grep hclutils          # ✓ empty — fully removed
```
</details>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

