### PR TITLE
fix: specify a pre-existing podman network

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -1985,9 +1985,15 @@ func resolveContainerIP(networkSettings *api.InspectNetworkSettings, networkName
 		return networkSettings.IPAddress
 	}
 	if netData, ok := networkSettings.Networks[networkName]; ok {
-		return netData.IPAddress
+		if netData.IPAddress != "" {
+			return netData.IPAddress
+		}
+		// IPv6-only network: no IPv4 address is assigned, so fall back to the
+		// global IPv6 address.
+		return netData.GlobalIPv6Address
 	}
-	return ""
+	// IPv6-only default network: same fallback for the top-level settings.
+	return networkSettings.GlobalIPv6Address
 }
 
 // ensureFifoAccessible ensures the log FIFO at fifoPath can be written to by

--- a/driver_test.go
+++ b/driver_test.go
@@ -2995,6 +2995,53 @@ func TestResolveContainerIP(t *testing.T) {
 			networkName: "default",
 			expectedIP:  "10.88.0.100",
 		},
+		{
+			name: "named IPv6-only network falls back to GlobalIPv6Address",
+			networkSettings: &api.InspectNetworkSettings{
+				InspectBasicNetworkConfig: api.InspectBasicNetworkConfig{
+					IPAddress: "",
+				},
+				Networks: map[string]*api.InspectAdditionalNetwork{
+					"localv6": {
+						InspectBasicNetworkConfig: api.InspectBasicNetworkConfig{
+							IPAddress:         "",
+							GlobalIPv6Address: "2a01:4f8:c2c:cd3c:fefe::10",
+						},
+					},
+				},
+			},
+			networkName: "localv6",
+			expectedIP:  "2a01:4f8:c2c:cd3c:fefe::10",
+		},
+		{
+			name: "named dual-stack network prefers IPv4 over IPv6",
+			networkSettings: &api.InspectNetworkSettings{
+				InspectBasicNetworkConfig: api.InspectBasicNetworkConfig{
+					IPAddress: "",
+				},
+				Networks: map[string]*api.InspectAdditionalNetwork{
+					"localv6": {
+						InspectBasicNetworkConfig: api.InspectBasicNetworkConfig{
+							IPAddress:         "10.89.1.10",
+							GlobalIPv6Address: "2a01:4f8:c2c:cd3c:fefe::10",
+						},
+					},
+				},
+			},
+			networkName: "localv6",
+			expectedIP:  "10.89.1.10",
+		},
+		{
+			name: "top-level IPv6-only falls back to GlobalIPv6Address",
+			networkSettings: &api.InspectNetworkSettings{
+				InspectBasicNetworkConfig: api.InspectBasicNetworkConfig{
+					IPAddress:         "",
+					GlobalIPv6Address: "fd00::42",
+				},
+			},
+			networkName: "default",
+			expectedIP:  "fd00::42",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes:https://github.com/hashicorp/nomad-driver-podman/issues/489

[**_Issue_**](https://hashicorp.atlassian.net/browse/NMD-1224)

An IPv6-only Podman network (localv6) reported that setting `network_mode = "localv6"` in task config was ignored — containers always ended up on the default IPv4 bridge (10.88.0.x) instead of the custom network.

**_This was fully resolved by this earlier PR:_**

- #509

**_Why this additional fix_**

PR #509 introduced custom network support. Custom Podman networks can be configured as pure IPv6-only (`podman network create --ipv6 --subnet fd00::/64 mynet with no IPv4 subnet`). On such networks, Podman leaves the IPAddress field empty and only populates GlobalIPv6Address.

The existing resolveContainerIP function only checked IPv4 fields, returning "" for IPv6-only networks. 

**`This is a correctness gap missed in #509`**. A function that resolves "the container's IP" should return the address that exists, not silently discard it because it's IPv6.

**_Before/After flow_**

Scenario | Network config | Before (returns) | After (returns)
-- | -- | -- | --
Default bridge (IPv4) | Standard podman bridge | 10.88.0.5 ✅ | 10.88.0.5 ✅
Named network, dual-stack | localv6 with IPv4 + IPv6 subnets | 10.89.1.3 ✅ | 10.89.1.3 ✅ (IPv4 preferred)
Named network, IPv6-only | mynet6 with only IPv6 subnet | "" ❌ | 2a01:4f8:c2c:cd3c:fefe::10 ✅
Default bridge, IPv6-only | System default configured as IPv6-only | "" ❌ | fd00::42 ✅




<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

