### PR TITLE
feat: added os, arch, and variant task config options for image pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * config: Adds support for plugin configuration `networking.default_rootless_mode` to override the default networking mode when run rootlessly. [[GH-495](https://github.com/hashicorp/nomad-driver-podman/pull/495)]
 * config: Support custom Podman network names for static IP/MAC options via `network_mode`. [[GH-509](https://github.com/hashicorp/nomad-driver-podman/pull/509)]
+* config: Added support for `os`, `arch` and `variant` task config options to override the platform of the image to pull. [[GH-]()]
 
 BUG FIXES:
 * api: Fixed file descriptor leak when getting logs from the task [[GH-508](https://github.com/hashicorp/nomad-driver-podman/pull/508)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 * config: Adds support for plugin configuration `networking.default_rootless_mode` to override the default networking mode when run rootlessly. [[GH-495](https://github.com/hashicorp/nomad-driver-podman/pull/495)]
 * config: Support custom Podman network names for static IP/MAC options via `network_mode`. [[GH-509](https://github.com/hashicorp/nomad-driver-podman/pull/509)]
-* config: Added support for `os`, `arch` and `variant` task config options to override the platform of the image to pull. [[GH-]()]
+* config: Added support for `os`, `arch` and `variant` task config options to override the platform of the image to pull. [[GH-514](https://github.com/hashicorp/nomad-driver-podman/pull/514)]
 
 BUG FIXES:
 * api: Fixed file descriptor leak when getting logs from the task [[GH-508](https://github.com/hashicorp/nomad-driver-podman/pull/508)]

--- a/README.md
+++ b/README.md
@@ -541,14 +541,14 @@ config {
 }
 ```
 
-  Notes:
-  - When any of these are set, the driver always pulls the image (the local image
-    cache lookup is platform-agnostic), so the correct variant is fetched. podman
-    skips the download if the matching image is already present.
-  - Nomad servers treat the task config as an opaque blob and cannot validate
-    these overrides at scheduling time. If a target node cannot run the requested
-    platform, use [`constraint`](https://developer.hashicorp.com/nomad/docs/job-specification/constraint)
-    blocks to pin the workload to compatible nodes, for example:
+  When any of these are set, the driver always pulls the image (the local image
+  cache lookup is platform-agnostic), so the correct variant is fetched. podman
+  skips the download if the matching image is already present.
+
+  Nomad servers treat the task config as an opaque blob and cannot validate these
+  overrides at scheduling time. If a target node cannot run the requested platform,
+  use [`constraint`](https://developer.hashicorp.com/nomad/docs/job-specification/constraint)
+  blocks to pin the workload to compatible nodes, for example:
 
 ```hcl
 constraint {

--- a/README.md
+++ b/README.md
@@ -527,6 +527,41 @@ config {
 }
 ```
 
+* **arch** / **os** / **variant** - (Optional) Override the architecture, operating
+  system and variant of the image to pull. These map to podman's `--arch`, `--os`
+  and `--variant` pull flags. When unset, the host platform defaults are used.
+  This is mainly useful for pulling Linux images on a FreeBSD host, or for pulling
+  a non-native architecture image on a host with emulation configured.
+
+```hcl
+config {
+  image = "docker.io/nginx:latest"
+  os    = "linux"
+  arch  = "amd64"
+}
+```
+
+  Notes:
+  - When any of these are set, the driver always pulls the image (the local image
+    cache lookup is platform-agnostic), so the correct variant is fetched. podman
+    skips the download if the matching image is already present.
+  - Nomad servers treat the task config as an opaque blob and cannot validate
+    these overrides at scheduling time. If a target node cannot run the requested
+    platform, use [`constraint`](https://developer.hashicorp.com/nomad/docs/job-specification/constraint)
+    blocks to pin the workload to compatible nodes, for example:
+
+```hcl
+constraint {
+  attribute = "${attr.kernel.name}"
+  value     = "freebsd"
+}
+
+config {
+  image = "docker.io/nginx:latest"
+  os    = "linux"
+}
+```
+
 * **readonly_rootfs** - (Optional)  true or false (default). Mount the rootfs as read-only.
 
 ```hcl

--- a/api/image_inspect.go
+++ b/api/image_inspect.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 var ImageNotFound = errors.New("No such Image")
@@ -42,6 +43,57 @@ func (c *API) ImageInspectID(ctx context.Context, image string) (string, error) 
 	err = json.Unmarshal(body, &inspectData)
 	if err != nil {
 		return "", err
+	}
+
+	return inspectData.Id, nil
+}
+
+type inspectPlatformImageResponse struct {
+	Id           string `json:"Id"`
+	Os           string `json:"Os"`
+	Architecture string `json:"Architecture"`
+	Variant      string `json:"Variant"`
+}
+
+// ImageInspectIDForPlatform inspects a local image by name and returns its image
+// ID, verifying that the image's recorded operating system, architecture and
+// variant match the requested platform. Empty platform fields are not checked.
+//
+// Unlike ImageInspectID, which resolves an image by name regardless of its
+// platform, this returns an error when the stored image does not match the
+// requested os/arch/variant. This lets callers confirm that a platform-specific
+// pull produced the expected image rather than just any image with that name.
+func (c *API) ImageInspectIDForPlatform(ctx context.Context, image, os, arch, variant string) (string, error) {
+	var inspectData inspectPlatformImageResponse
+
+	res, err := c.Get(ctx, fmt.Sprintf("/v1.0.0/libpod/images/%s/json", image))
+	if err != nil {
+		return "", err
+	}
+
+	defer ignoreClose(res.Body)
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	if res.StatusCode == http.StatusNotFound {
+		return "", ImageNotFound
+	}
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cannot inspect image, status code: %d: %s", res.StatusCode, body)
+	}
+	if err := json.Unmarshal(body, &inspectData); err != nil {
+		return "", err
+	}
+
+	if os != "" && !strings.EqualFold(os, inspectData.Os) {
+		return "", fmt.Errorf("image %s os %q does not match requested %q", image, inspectData.Os, os)
+	}
+	if arch != "" && !strings.EqualFold(arch, inspectData.Architecture) {
+		return "", fmt.Errorf("image %s architecture %q does not match requested %q", image, inspectData.Architecture, arch)
+	}
+	if variant != "" && !strings.EqualFold(variant, inspectData.Variant) {
+		return "", fmt.Errorf("image %s variant %q does not match requested %q", image, inspectData.Variant, variant)
 	}
 
 	return inspectData.Id, nil

--- a/api/image_pull.go
+++ b/api/image_pull.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/hashicorp/nomad-driver-podman/registry"
 )
@@ -36,6 +37,19 @@ func (c *API) ImagePull(ctx context.Context, pullConfig *registry.PullConfig) (s
 	}
 
 	urlPath := fmt.Sprintf("/v1.0.0/libpod/images/pull?reference=%s&tlsVerify=%t", repository, tlsVerify)
+
+	// Optionally override the platform of the image to pull. These map to
+	// podman's --arch, --os and --variant flags and are passed to the libpod
+	// pull endpoint as the Arch, OS and Variant query parameters.
+	if pullConfig.Arch != "" {
+		urlPath += "&Arch=" + url.QueryEscape(pullConfig.Arch)
+	}
+	if pullConfig.OS != "" {
+		urlPath += "&OS=" + url.QueryEscape(pullConfig.OS)
+	}
+	if pullConfig.Variant != "" {
+		urlPath += "&Variant=" + url.QueryEscape(pullConfig.Variant)
+	}
 
 	res, err := c.PostWithHeaders(ctx, urlPath, nil, headers)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -107,6 +107,9 @@ var (
 		"working_dir":    hclspec.NewAttr("working_dir", "string", false),
 		"hostname":       hclspec.NewAttr("hostname", "string", false),
 		"image":          hclspec.NewAttr("image", "string", true),
+		"arch":           hclspec.NewAttr("arch", "string", false),
+		"os":             hclspec.NewAttr("os", "string", false),
+		"variant":        hclspec.NewAttr("variant", "string", false),
 		"image_pull_timeout": hclspec.NewDefault(
 			hclspec.NewAttr("image_pull_timeout", "string", false),
 			hclspec.NewLiteral(`"5m"`),
@@ -270,6 +273,9 @@ type TaskConfig struct {
 	Init              bool               `codec:"init"`
 	Tty               bool               `codec:"tty"`
 	ForcePull         bool               `codec:"force_pull"`
+	Arch              string             `codec:"arch"`
+	OS                string             `codec:"os"`
+	Variant           string             `codec:"variant"`
 	Privileged        bool               `codec:"privileged"`
 	ReadOnlyRootfs    bool               `codec:"readonly_rootfs"`
 	UserNS            string             `codec:"userns"`

--- a/config_test.go
+++ b/config_test.go
@@ -88,6 +88,26 @@ func TestConfig_ForcePull(t *testing.T) {
 	must.Eq(t, true, tc.ForcePull)
 }
 
+func TestConfig_Platform(t *testing.T) {
+	ci.Parallel(t)
+
+	parser := hclutils.NewConfigParser(taskConfigSpec)
+	validHCL := `
+  config {
+		image = "docker://nginx"
+		os = "linux"
+		arch = "amd64"
+		variant = "v8"
+  }
+`
+
+	var tc *TaskConfig
+	parser.ParseHCL(t, validHCL, &tc)
+	must.Eq(t, "linux", tc.OS)
+	must.Eq(t, "amd64", tc.Arch)
+	must.Eq(t, "v8", tc.Variant)
+}
+
 func TestConfig_CPUHardLimit(t *testing.T) {
 	ci.Parallel(t)
 

--- a/config_test.go
+++ b/config_test.go
@@ -87,26 +87,6 @@ func TestConfig_ForcePull(t *testing.T) {
 	must.Eq(t, true, tc.ForcePull)
 }
 
-func TestConfig_Platform(t *testing.T) {
-	ci.Parallel(t)
-
-	parser := newConfigParser(taskConfigSpec)
-	validHCL := `
-  config {
-		image = "docker://nginx"
-		os = "linux"
-		arch = "amd64"
-		variant = "v8"
-  }
-`
-
-	var tc *TaskConfig
-	parser.ParseHCL(t, validHCL, &tc)
-	must.Eq(t, "linux", tc.OS)
-	must.Eq(t, "amd64", tc.Arch)
-	must.Eq(t, "v8", tc.Variant)
-}
-
 func TestConfig_CPUHardLimit(t *testing.T) {
 	ci.Parallel(t)
 

--- a/config_test.go
+++ b/config_test.go
@@ -87,6 +87,26 @@ func TestConfig_ForcePull(t *testing.T) {
 	must.Eq(t, true, tc.ForcePull)
 }
 
+func TestConfig_Platform(t *testing.T) {
+	ci.Parallel(t)
+
+	parser := newConfigParser(taskConfigSpec)
+	validHCL := `
+  config {
+		image = "docker://nginx"
+		os = "linux"
+		arch = "amd64"
+		variant = "v8"
+  }
+`
+
+	var tc *TaskConfig
+	parser.ParseHCL(t, validHCL, &tc)
+	must.Eq(t, "linux", tc.OS)
+	must.Eq(t, "amd64", tc.Arch)
+	must.Eq(t, "v8", tc.Variant)
+}
+
 func TestConfig_CPUHardLimit(t *testing.T) {
 	ci.Parallel(t)
 

--- a/driver.go
+++ b/driver.go
@@ -1235,8 +1235,6 @@ func sliceMergeUlimit(ulimitsRaw map[string]string) ([]spec.POSIXRlimit, error) 
 	return ulimits, nil
 }
 
-// Creates the requested image if missing from storage
-// returns the 64-byte image ID as an unique image identifier
 // imagePlatform holds optional OS/architecture overrides for an image pull.
 // These correspond to podman's --arch, --os and --variant flags.
 type imagePlatform struct {
@@ -1245,11 +1243,13 @@ type imagePlatform struct {
 	variant string
 }
 
-// set reports whether any platform override has been requested.
-func (p imagePlatform) set() bool {
+// isSet reports whether any platform override has been requested.
+func (p imagePlatform) isSet() bool {
 	return p.arch != "" || p.os != "" || p.variant != ""
 }
 
+// Creates the requested image if missing from storage
+// returns the 64-byte image ID as an unique image identifier
 func (d *Driver) createImage(
 	image string,
 	auth *TaskAuthConfig,
@@ -1307,7 +1307,7 @@ func (d *Driver) createImage(
 	// variant is fetched (podman skips the download if it is already present).
 	// Images loaded from an archive cannot be pulled from a registry, so the
 	// platform override does not apply to them and the cache shortcut is kept.
-	usePlatform := platform.set() && !loadedFromArchive
+	usePlatform := platform.isSet() && !loadedFromArchive
 	if !forcePull && !usePlatform && imageID != "" {
 		d.logger.Debug("Found imageID", imageID, "for image", imageName, "in local storage")
 		return imageID, nil
@@ -1348,7 +1348,7 @@ func (d *Driver) createImage(
 	// are not collapsed into a single result.
 	pullKey := imageName
 	if usePlatform {
-		pullKey = strings.Join([]string{imageName, platform.os, platform.arch, platform.variant}, "|")
+		pullKey = fmt.Sprintf("%s|%s|%s|%s", imageName, platform.os, platform.arch, platform.variant)
 	}
 
 	result, err, _ := d.pullGroup.Do(pullKey, func() (interface{}, error) {

--- a/driver.go
+++ b/driver.go
@@ -974,6 +974,11 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			&podmanTaskConfig.Auth,
 			podmanTaskConfig.AuthSoftFail,
 			podmanTaskConfig.ForcePull,
+			imagePlatform{
+				arch:    podmanTaskConfig.Arch,
+				os:      podmanTaskConfig.OS,
+				variant: podmanTaskConfig.Variant,
+			},
 			podmanClient,
 			imagePullTimeout,
 			cfg,
@@ -1232,17 +1237,32 @@ func sliceMergeUlimit(ulimitsRaw map[string]string) ([]spec.POSIXRlimit, error) 
 
 // Creates the requested image if missing from storage
 // returns the 64-byte image ID as an unique image identifier
+// imagePlatform holds optional OS/architecture overrides for an image pull.
+// These correspond to podman's --arch, --os and --variant flags.
+type imagePlatform struct {
+	arch    string
+	os      string
+	variant string
+}
+
+// set reports whether any platform override has been requested.
+func (p imagePlatform) set() bool {
+	return p.arch != "" || p.os != "" || p.variant != ""
+}
+
 func (d *Driver) createImage(
 	image string,
 	auth *TaskAuthConfig,
 	authSoftFail bool,
 	forcePull bool,
+	platform imagePlatform,
 	podmanClient *api.API,
 	imagePullTimeout time.Duration,
 	cfg *drivers.TaskConfig,
 ) (string, error) {
 	var imageID string
 	imageName := image
+	loadedFromArchive := false
 	// If it is a shortname, we should not have to worry
 	// Let podman deal with it according to user configuration
 	if !shortnames.IsShortName(image) {
@@ -1271,6 +1291,7 @@ func (d *Driver) createImage(
 			if err != nil {
 				return imageID, fmt.Errorf("error while loading image: %w", err)
 			}
+			loadedFromArchive = true
 		}
 	}
 
@@ -1280,7 +1301,14 @@ func (d *Driver) createImage(
 		// to pull the image instead
 		d.logger.Warn("Unable to check for local image", "image", imageName, "error", err)
 	}
-	if !forcePull && imageID != "" {
+	// The local image lookup above is platform-agnostic: it resolves an image
+	// by name regardless of its OS/architecture. When a platform override is
+	// requested, bypass the cache shortcut and always pull so the correct
+	// variant is fetched (podman skips the download if it is already present).
+	// Images loaded from an archive cannot be pulled from a registry, so the
+	// platform override does not apply to them and the cache shortcut is kept.
+	usePlatform := platform.set() && !loadedFromArchive
+	if !forcePull && !usePlatform && imageID != "" {
 		d.logger.Debug("Found imageID", imageID, "for image", imageName, "in local storage")
 		return imageID, nil
 	}
@@ -1306,8 +1334,24 @@ func (d *Driver) createImage(
 		CredentialsHelper: d.config.Auth.Helper,
 		AuthSoftFail:      authSoftFail,
 	}
+	// Only thread the platform override through for pullable references. For
+	// archive-loaded images these fields are meaningless and the image is
+	// already present locally.
+	if !loadedFromArchive {
+		pc.Arch = platform.arch
+		pc.OS = platform.os
+		pc.Variant = platform.variant
+	}
 
-	result, err, _ := d.pullGroup.Do(imageName, func() (interface{}, error) {
+	// Key the singleflight group on both the image name and the requested
+	// platform so concurrent pulls of the same image for different platforms
+	// are not collapsed into a single result.
+	pullKey := imageName
+	if usePlatform {
+		pullKey = strings.Join([]string{imageName, platform.os, platform.arch, platform.variant}, "|")
+	}
+
+	result, err, _ := d.pullGroup.Do(pullKey, func() (interface{}, error) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), imagePullTimeout)
 		defer cancel()

--- a/driver_test.go
+++ b/driver_test.go
@@ -2452,7 +2452,15 @@ func createInspectImagePlatform(t *testing.T, image string, platform imagePlatfo
 	driver := getPodmanDriver(t, d)
 	idTest, err := driver.createImage(image, &TaskAuthConfig{}, false, false, platform, driver.defaultPodman, 5*time.Minute, task)
 	must.NoError(t, err)
-	must.NotEq(t, "", idTest)
+
+	// Independently inspect the stored image for the requested platform and
+	// confirm createImage returned that exact image ID. This verifies the
+	// correct platform variant was pulled, not merely that some image with the
+	// given name exists.
+	idRef, err := driver.defaultPodman.ImageInspectIDForPlatform(
+		context.Background(), image, platform.os, platform.arch, platform.variant)
+	must.NoError(t, err)
+	must.Eq(t, idRef, idTest)
 
 	return idTest
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -2349,6 +2349,39 @@ func Test_createImage(t *testing.T) {
 	}
 }
 
+func Test_createImagePlatform(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		Name     string
+		Image    string
+		Platform imagePlatform
+	}{
+		{
+			Name:     "amd64",
+			Image:    "docker.io/library/alpine:latest",
+			Platform: imagePlatform{os: "linux", arch: "amd64"},
+		},
+		{
+			Name:     "arm64",
+			Image:    "docker.io/library/alpine:latest",
+			Platform: imagePlatform{os: "linux", arch: "arm64"},
+		},
+	}
+
+	ids := make(map[string]string, len(testCases))
+	for _, testCase := range testCases {
+		ids[testCase.Name] = createInspectImagePlatform(t, testCase.Image, testCase.Platform)
+	}
+
+	// The platform override must actually take effect: the same image reference
+	// pulled for two different architectures resolves to two different image
+	// IDs. This also exercises the cache-bypass (no force_pull) and the
+	// per-platform singleflight key.
+	must.NotEq(t, ids["amd64"], ids["arm64"],
+		must.Sprint("expected the amd64 and arm64 overrides to resolve to different image IDs"))
+}
+
 func Test_createImageArchives(t *testing.T) {
 	ci.Parallel(t)
 
@@ -2405,6 +2438,23 @@ func createInspectImage(t *testing.T, image, reference string) {
 	idRef, err := driver.defaultPodman.ImageInspectID(context.Background(), reference)
 	must.NoError(t, err)
 	must.Eq(t, idRef, idTest)
+}
+
+func createInspectImagePlatform(t *testing.T, image string, platform imagePlatform) string {
+	d := podmanDriverHarness(t, nil)
+
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "inspectImagePlatform",
+		AllocID:   uuid.Generate(),
+		Resources: createBasicResources(),
+	}
+	driver := getPodmanDriver(t, d)
+	idTest, err := driver.createImage(image, &TaskAuthConfig{}, false, false, platform, driver.defaultPodman, 5*time.Minute, task)
+	must.NoError(t, err)
+	must.NotEq(t, "", idTest)
+
+	return idTest
 }
 
 func Test_setTaskCpuset(t *testing.T) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -2239,7 +2239,7 @@ func startDestroyInspectImage(t *testing.T, image string, taskName string) {
 		Resources: createBasicResources(),
 	}
 	driver := getPodmanDriver(t, d)
-	imageID, err := driver.createImage(image, &TaskAuthConfig{}, false, false, driver.defaultPodman, 5*time.Minute, task)
+	imageID, err := driver.createImage(image, &TaskAuthConfig{}, false, false, imagePlatform{}, driver.defaultPodman, 5*time.Minute, task)
 	must.NoError(t, err)
 	must.Eq(t, imageID, inspectData.Image)
 }
@@ -2320,7 +2320,7 @@ insecure = true`
 		// Pull image using our proxy.
 		image := "localhost:5000/quay/busybox:latest"
 		driver := getPodmanDriver(t, d)
-		_, err = driver.createImage(image, &TaskAuthConfig{}, false, true, driver.defaultPodman, 3*time.Second, task)
+		_, err = driver.createImage(image, &TaskAuthConfig{}, false, true, imagePlatform{}, driver.defaultPodman, 3*time.Second, task)
 		resultCh <- err
 	}()
 
@@ -2399,7 +2399,7 @@ func createInspectImage(t *testing.T, image, reference string) {
 		Resources: createBasicResources(),
 	}
 	driver := getPodmanDriver(t, d)
-	idTest, err := driver.createImage(image, &TaskAuthConfig{}, false, false, driver.defaultPodman, 5*time.Minute, task)
+	idTest, err := driver.createImage(image, &TaskAuthConfig{}, false, false, imagePlatform{}, driver.defaultPodman, 5*time.Minute, task)
 	must.NoError(t, err)
 
 	idRef, err := driver.defaultPodman.ImageInspectID(context.Background(), reference)

--- a/registry/authentication.go
+++ b/registry/authentication.go
@@ -18,6 +18,12 @@ type PullConfig struct {
 	CredentialsFile   string
 	CredentialsHelper string
 	AuthSoftFail      bool
+	// Arch, OS and Variant override the architecture, operating system and
+	// variant of the image to pull. When empty, the host defaults are used.
+	// These map to podman's --arch, --os and --variant pull flags.
+	Arch    string
+	OS      string
+	Variant string
 }
 
 // BasicConfig returns the Basic-Auth level of configuration.
@@ -87,6 +93,9 @@ func (pc *PullConfig) Log(logger hclog.Logger) {
 		"token", token,
 		"helper", helper,
 		"file", file,
+		"arch", pc.Arch,
+		"os", pc.OS,
+		"variant", pc.Variant,
 	)
 }
 


### PR DESCRIPTION
Fixes:https://github.com/hashicorp/nomad-driver-podman/issues/491

**_Summary_**

Added three optional task config options — os, arch, and variant — that let a job pull a specific platform variant of a container image, mirroring podman's --os, --arch, and --variant pull flags. 

**[Issue](https://hashicorp.atlassian.net/browse/NMD-1320)**

Users had no way to control which platform variant of an image the driver pulled. The driver always pulled the host-default platform.

**_Fix_**

Thread an optional platform override from job config all the way to the podman pull request, and harden the cache/concurrency paths so the override is always honoured:
- `config.go` :  register os/arch/variant in the task config schema and struct (optional, backward compatible).
- `registry.PullConfig` :  carry the values from the driver to the API layer.
- `image_pull.go `: append OS/Arch/Variant query params to the libpod pull request (only when set).
- `driver.go`: bypass the platform-agnostic local-image cache shortcut when an override is requested, so the correct variant is always pulled (podman skips re-download if already present — no force_pull needed),
skip the override for oci-archive/docker-archive images (they're loaded, not pulled),
include the platform in the singleflight pull key so concurrent pulls of different platforms aren't collapsed into one.

**_Before/After Flow_**

Aspect | Before | After
-- | -- | --
Config keys | os/arch/variant rejected at validation (No argument or block type is named "arch") | Accepted as optional task config
Pull request | reference + tlsVerify only | Adds OS/Arch/Variant query params when set
Platform selection | Always host default | User-selectable per task
Cached wrong-platform image | Returned as-is, override ignored | Cache bypassed, correct variant pulled
Concurrent different-platform pulls | N/A (feature didn't exist; singleflight keyed on name only) | Singleflight keyed per platform, so different-platform pulls aren't collapsed
Archive (oci-archive/docker-archive) | n/a | Override correctly skipped
force_pull required? | — | No — override alone triggers the right pull

**_Example flow (arm64 host with amd64 emulation)_**

Before — no way to express it:

```
config {
  image = "docker.io/library/alpine:latest"
  arch  = "amd64"   # ❌ rejected: "No argument or block type is named \"arch\""
}
```
**_After — works:_**

```
config {
  image   = "docker.io/library/alpine:latest"
  command = "uname"
  args    = ["-m"]
  arch    = "amd64"        # forces linux/amd64 variant
  # os      = "linux"      # optional
  # variant = "v8"         # optional
}
```

```
$ uname -m   (inside container)
x86_64                      # amd64 variant ran under emulation
$ podman image inspect ... --format '{{.Os}}/{{.Architecture}}'
linux/amd64
```

Job config | Result on arm64 host
-- | --
arch = "amd64" | linux/amd64 pulled, runs under emulation → x86_64
os = "linux" (only) | host-matching linux/arm64 pulled → aarch64
os = "linux" + arch = "amd64" | linux/amd64 pulled → x86_64
(none specified) | host default — unchanged behaviour

**_Backward compatibility_**
- All three options are optional. Jobs that don't set them behave exactly as before (host-default platform).

Testing:
<details>

- Before Flow: 

```
2026-06-11T22:37:00.520+0530 [ERROR] client.alloc_runner.task_runner: running driver failed: alloc_id=e9a5499a-860e-54be-db02-704d6c9a39ec task=uname
  error=
  | 2 errors occurred:
  | \t* failed to parse config: 
  | \t* Invalid label: No argument or block type is named "arch". Did you mean "auth"?
```
 
```
2026-06-11T22:53:08.519+0530 [INFO]  client.alloc_runner.task_runner: Task event: alloc_id=6294bcf5-ae0d-3e7c-cd34-9d98f2f0df36 task=uname type="Failed Validation"
  msg=
  | 2 errors occurred:
  | \t* failed to parse config: 
  | \t* Invalid label: No argument or block type is named "os".
```


- Current Flow:

**1. Job-os-arch**

```
job "issue-491-os-arch" {
  type = "batch"

  group "platform" {
    task "uname" {
      driver = "podman"

      config {
        image   = "docker.io/library/alpine:latest"
        command = "uname"
        args    = ["-m"]
        os      = "linux"
        arch    = "amd64"
      }

      resources {
        cpu    = 100
        memory = 64
      }
    }
  }
}
```


```
[after] uname -m reported by the container:
2026-06-11T23:05:26.256444450+05:30 stdout F x86_64

[after] Recent task events:
  Recent Events:
  Time                       Type        Description
  2026-06-11T23:05:27+05:30  Terminated  Exit Code: 0
  2026-06-11T23:05:26+05:30  Started     Task started by client
  2026-06-11T23:05:22+05:30  Driver      Pulling image docker.io/library/alpine:latest
  2026-06-11T23:05:22+05:30  Task Setup  Building Task Directory
  2026-06-11T23:05:22+05:30  Received    Task received by client

[after] Locally stored image platform (podman image inspect):
  linux/amd64
----------------------------------------------------------------
VERDICT [after]: PASS - arch override HONOURED (amd64 image ran on this arm64 host)
```

**2. Job-os**

```
job "issue-491-os" {
  type = "batch"

  group "platform" {
    task "uname" {
      driver = "podman"

      config {
        image   = "docker.io/library/alpine:latest"
        command = "uname"
        args    = ["-m"]
        os      = "linux"
      }

      resources {
        cpu    = 100
        memory = 64
      }
    }
  }
}
```

```
[after] uname -m reported by the container:
2026-06-11T23:05:16.605599600+05:30 stdout F aarch64

[after] Recent task events:
  Recent Events:
  Time                       Type        Description
  2026-06-11T23:05:17+05:30  Terminated  Exit Code: 0
  2026-06-11T23:05:16+05:30  Started     Task started by client
  2026-06-11T23:05:12+05:30  Driver      Pulling image docker.io/library/alpine:latest
  2026-06-11T23:05:12+05:30  Task Setup  Building Task Directory
  2026-06-11T23:05:12+05:30  Received    Task received by client

[after] Locally stored image platform (podman image inspect):
  linux/arm64
----------------------------------------------------------------
VERDICT [after]: PASS - os override accepted; native linux/arm64 image ran
```

**3. Job-arch**

```
job "issue-491-arch" {
  type = "batch"

  group "platform" {
    task "uname" {
      driver = "podman"

      config {
        image   = "docker.io/library/alpine:latest"
        command = "uname"
        args    = ["-m"]
        arch    = "amd64"
      }

      resources {
        cpu    = 100
        memory = 64
      }
    }
  }
}
```

```
[after] uname -m reported by the container:
2026-06-11T23:05:06.656173017+05:30 stdout F x86_64

[after] Recent task events:
  Recent Events:
  Time                       Type        Description
  2026-06-11T23:05:07+05:30  Terminated  Exit Code: 0
  2026-06-11T23:05:06+05:30  Started     Task started by client
  2026-06-11T23:05:02+05:30  Driver      Pulling image docker.io/library/alpine:latest
  2026-06-11T23:05:02+05:30  Task Setup  Building Task Directory
  2026-06-11T23:05:02+05:30  Received    Task received by client

[after] Locally stored image platform (podman image inspect):
  linux/amd64
----------------------------------------------------------------
VERDICT [after]: PASS - arch override HONOURED (amd64 image ran on this arm64 host)
```

<img width="1168" height="224" alt="Screenshot 2026-06-11 at 11 11 19 PM" src="https://github.com/user-attachments/assets/068e5af7-a70d-4566-a489-008479d9cc58" />


</details>


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

