### PR TITLE
feat: added ipc_mode task config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * config: Adds support for plugin configuration `networking.default_rootless_mode` to override the default networking mode when run rootlessly. [[GH-495](https://github.com/hashicorp/nomad-driver-podman/pull/495)]
 * config: Support custom Podman network names for static IP/MAC options via `network_mode`. [[GH-509](https://github.com/hashicorp/nomad-driver-podman/pull/509)]
+* config: Added `ipc_mode` task configuration option to control the container IPC    namespace (`host`, `private`, `shareable`, `none`, `container:<id>`, `ns:<path>`, `task:<name>`) [[GH-515](https://github.com/hashicorp/nomad-driver-podman/pull/515)]
 * build: Eliminated transitive dependency on Docker packages via `hclutils`.[[GH-512](https://github.com/hashicorp/nomad-driver-podman/pull/512)]
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -565,6 +565,29 @@ config {
 }
 ```
 
+* **ipc_mode** - (Optional) Set the [IPC namespace mode](https://docs.podman.io/en/latest/markdown/podman-run.1.html#ipc-ipc) for the container. When unset, Podman uses its default (a `private` IPC namespace).
+
+* `host`: use the host's IPC namespace. Note: this gives the container access to
+  host IPC primitives and is therefore considered insecure.
+* `private`: create a private IPC namespace (the default).
+* `shareable`: create a private IPC namespace that other containers may join.
+* `none`: create a private IPC namespace without mounting `/dev/shm`.
+* `container:id`: join the IPC namespace of another podman container.
+* `ns:path`: join the IPC namespace at the given path.
+* `task:name-of-other-task`: join the IPC namespace of another task in the same
+  allocation. This is useful for sharing `/dev/shm` between tasks, for example
+  with the NVIDIA Multi-Process Service (MPS) for GPU sharing.
+
+`ipc_mode` cannot be combined with `shm_size` unless it is set to
+`private` or `shareable`, since the other modes do not own the container's
+`/dev/shm`.
+
+```hcl
+config {
+  ipc_mode = "task:mps-daemon"
+}
+```
+
 * **pids_limit** - (Optional) An integer value that specifies the pid limit for the container.
 
 ```hcl

--- a/api/structs.go
+++ b/api/structs.go
@@ -559,6 +559,9 @@ const (
 	FromPod NamespaceMode = "pod"
 	// Private indicates the namespace is private
 	Private NamespaceMode = "private"
+	// Shareable indicates the IPC namespace is private but can be shared
+	// with other containers (e.g. via --ipc=container:<id>)
+	Shareable NamespaceMode = "shareable"
 	// NoNetwork indicates no network namespace should
 	// be joined.  loopback should still exists
 	NoNetwork NamespaceMode = "none"

--- a/config.go
+++ b/config.go
@@ -126,6 +126,7 @@ var (
 		"memory_swap":        hclspec.NewAttr("memory_swap", "string", false),
 		"memory_swappiness":  hclspec.NewAttr("memory_swappiness", "number", false),
 		"network_mode":       hclspec.NewAttr("network_mode", "string", false),
+		"ipc_mode":           hclspec.NewAttr("ipc_mode", "string", false),
 		"oom_score_adj":      hclspec.NewAttr("oom_score_adj", "number", false),
 		"extra_hosts":        hclspec.NewAttr("extra_hosts", "list(string)", false),
 		"pids_limit":         hclspec.NewAttr("pids_limit", "number", false),
@@ -257,6 +258,7 @@ type TaskConfig struct {
 	MemoryReservation string              `codec:"memory_reservation"`
 	MemorySwap        string              `codec:"memory_swap"`
 	NetworkMode       string              `codec:"network_mode"`
+	IPCMode           string              `codec:"ipc_mode"`
 	OOMScoreAdj       int16               `codec:"oom_score_adj"`
 	ExtraHosts        []string            `codec:"extra_hosts"`
 	CPUCFSPeriod      uint64              `codec:"cpu_cfs_period"`

--- a/config_test.go
+++ b/config_test.go
@@ -168,6 +168,22 @@ func TestConfig_PodmanOOMScoreAdj(t *testing.T) {
 	must.Eq(t, "default", tc.Socket)
 }
 
+func TestConfig_IPCMode(t *testing.T) {
+	ci.Parallel(t)
+
+	parser := newConfigParser(taskConfigSpec)
+	validHCL := `
+	config {
+		image = "docker://redis"
+		ipc_mode = "host"
+	}
+	`
+
+	var tc *TaskConfig
+	parser.ParseHCL(t, validHCL, &tc)
+	must.Eq(t, "host", tc.IPCMode)
+}
+
 func TestPluginConfig_Parsing(t *testing.T) {
 	ci.Parallel(t)
 

--- a/driver.go
+++ b/driver.go
@@ -756,6 +756,45 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		createOpts.ContainerStorageConfig.ShmSize = &shmsize
 	}
 
+	// Populate the IPC namespace mode only if configured. When unset, Podman
+	// applies its default (private). This mirrors the network_mode handling and
+	// supports the same task: convenience for sharing within an allocation,
+	// which is required for use cases such as NVIDIA MPS GPU sharing.
+	if podmanTaskConfig.IPCMode != "" {
+		// shm_size only makes sense when the container owns its /dev/shm, i.e.
+		// a private or shareable IPC namespace. host/none/container/ns either
+		// inherit an external /dev/shm or have none, so reject the combination
+		// to fail fast with a clear error instead of letting Podman error out.
+		ipcMode := podmanTaskConfig.IPCMode
+		ownsShm := ipcMode == "private" || ipcMode == "shareable"
+		if podmanTaskConfig.ShmSize != "" && !ownsShm {
+			return nil, nil, fmt.Errorf("shm_size cannot be used with ipc_mode=%q; it requires a private or shareable IPC namespace", ipcMode)
+		}
+
+		switch {
+		case ipcMode == "host":
+			createOpts.ContainerStorageConfig.IpcNS.NSMode = api.Host
+		case ipcMode == "private":
+			createOpts.ContainerStorageConfig.IpcNS.NSMode = api.Private
+		case ipcMode == "shareable":
+			createOpts.ContainerStorageConfig.IpcNS.NSMode = api.Shareable
+		case ipcMode == "none":
+			createOpts.ContainerStorageConfig.IpcNS.NSMode = api.NamespaceMode("none")
+		case strings.HasPrefix(ipcMode, "container:"):
+			createOpts.ContainerStorageConfig.IpcNS.NSMode = api.FromContainer
+			createOpts.ContainerStorageConfig.IpcNS.Value = strings.TrimPrefix(ipcMode, "container:")
+		case strings.HasPrefix(ipcMode, "ns:"):
+			createOpts.ContainerStorageConfig.IpcNS.NSMode = api.Path
+			createOpts.ContainerStorageConfig.IpcNS.Value = strings.TrimPrefix(ipcMode, "ns:")
+		case strings.HasPrefix(ipcMode, "task:"):
+			otherTaskName := strings.TrimPrefix(ipcMode, "task:")
+			createOpts.ContainerStorageConfig.IpcNS.NSMode = api.FromContainer
+			createOpts.ContainerStorageConfig.IpcNS.Value = BuildContainerNameForTask(otherTaskName, cfg)
+		default:
+			return nil, nil, fmt.Errorf("invalid ipc_mode %q: expected one of host, private, shareable, none, container:<id>, ns:<path>, task:<name>", ipcMode)
+		}
+	}
+
 	// Get Podman version as networking option availability depends on the version
 	apiVersion := podmanClient.GetAPIVersion()
 	versionValue, _ := version2.NewVersion(apiVersion)

--- a/driver_test.go
+++ b/driver_test.go
@@ -2136,15 +2136,15 @@ func TestPodmanDriver_IPCModes(t *testing.T) {
 			must.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
 
 			d := podmanDriverHarness(t, nil)
-			defer d.MkAllocDir(task, true)()
+			t.Cleanup(d.MkAllocDir(task, true))
 
 			containerName := BuildContainerName(task)
 			_, _, err := d.StartTask(task)
 			must.NoError(t, err)
 
-			defer func() {
+			t.Cleanup(func() {
 				_ = d.DestroyTask(task.ID, true)
-			}()
+			})
 
 			must.NoError(t, d.WaitUntilStarted(task.ID, 20*time.Second))
 
@@ -2196,27 +2196,25 @@ func TestPodmanDriver_IPCMode_Task(t *testing.T) {
 	must.NoError(t, sidecarTask.EncodeConcreteDriverConfig(&sidecarTaskCfg))
 
 	mainHarness := podmanDriverHarness(t, nil)
-	mainCleanup := mainHarness.MkAllocDir(mainTask, true)
-	defer mainCleanup()
+	t.Cleanup(mainHarness.MkAllocDir(mainTask, true))
 
 	_, _, err := mainHarness.StartTask(mainTask)
 	must.NoError(t, err)
-	defer func() {
+	t.Cleanup(func() {
 		_ = mainHarness.DestroyTask(mainTask.ID, true)
-	}()
+	})
 
 	// ensure the main task is running before the sidecar attempts to join
 	must.NoError(t, mainHarness.WaitUntilStarted(mainTask.ID, 20*time.Second))
 
 	sidecarHarness := podmanDriverHarness(t, nil)
-	sidecarCleanup := sidecarHarness.MkAllocDir(sidecarTask, true)
-	defer sidecarCleanup()
+	t.Cleanup(sidecarHarness.MkAllocDir(sidecarTask, true))
 
 	_, _, err = sidecarHarness.StartTask(sidecarTask)
 	must.NoError(t, err)
-	defer func() {
+	t.Cleanup(func() {
 		_ = sidecarHarness.DestroyTask(sidecarTask.ID, true)
-	}()
+	})
 
 	// Attempt to wait
 	waitCh, err := sidecarHarness.WaitTask(context.Background(), sidecarTask.ID)
@@ -2225,7 +2223,7 @@ func TestPodmanDriver_IPCMode_Task(t *testing.T) {
 	select {
 	case res := <-waitCh:
 		// should have a exitcode=0 result
-		must.True(t, res.Successful())
+		must.True(t, res.Successful(), must.Sprint("expected sidecar task to be successful"))
 	case <-time.After(15 * time.Second):
 		t.Fatalf("Sidecar did not exit in time")
 	}
@@ -2268,7 +2266,7 @@ func TestPodmanDriver_IPCMode_ShmSizeConflict(t *testing.T) {
 			must.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
 
 			d := podmanDriverHarness(t, nil)
-			defer d.MkAllocDir(task, true)()
+			t.Cleanup(d.MkAllocDir(task, true))
 
 			_, _, err := d.StartTask(task)
 			must.Error(t, err)

--- a/driver_test.go
+++ b/driver_test.go
@@ -2106,6 +2106,179 @@ func TestPodmanDriver_NetworkMode_Task(t *testing.T) {
 	must.StrContains(t, tasklog, "127.0.0.1:6748")
 }
 
+// check ipc_mode configuration is applied to the container. Each mode listed
+// here is reported back verbatim by podman via inspect.
+func TestPodmanDriver_IPCModes(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		mode     string
+		expected string
+	}{
+		{mode: "host", expected: "host"},
+		{mode: "private", expected: "private"},
+		{mode: "shareable", expected: "shareable"},
+		{mode: "none", expected: "none"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s_mode_%s", t.Name(), tc.mode), func(t *testing.T) {
+			taskCfg := newTaskConfig("", busyboxLongRunningCmd)
+			taskCfg.IPCMode = tc.mode
+
+			task := &drivers.TaskConfig{
+				ID:        uuid.Generate(),
+				Name:      fmt.Sprintf("ipc_mode_%s", tc.mode),
+				AllocID:   uuid.Generate(),
+				Resources: createBasicResources(),
+			}
+
+			must.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+			d := podmanDriverHarness(t, nil)
+			defer d.MkAllocDir(task, true)()
+
+			containerName := BuildContainerName(task)
+			_, _, err := d.StartTask(task)
+			must.NoError(t, err)
+
+			defer func() {
+				_ = d.DestroyTask(task.ID, true)
+			}()
+
+			must.NoError(t, d.WaitUntilStarted(task.ID, 20*time.Second))
+
+			inspectData, err := getPodmanDriver(t, d).defaultPodman.ContainerInspect(context.Background(), containerName)
+			must.NoError(t, err)
+			must.Eq(t, tc.expected, inspectData.HostConfig.IpcMode)
+		})
+	}
+}
+
+// let a task join the IPC namespace of another container via ipc_mode=task:.
+// This is the pattern used for NVIDIA MPS, where clients share the IPC
+// namespace (and thus /dev/shm) of the MPS control daemon. We verify the
+// sharing by writing a marker file to /dev/shm in the main task and
+// confirming the sidecar, which joins that IPC namespace, can read it.
+func TestPodmanDriver_IPCMode_Task(t *testing.T) {
+	ci.Parallel(t)
+
+	allocId := uuid.Generate()
+
+	// main task writes a marker into the shared /dev/shm then stays alive
+	mainTaskCfg := newTaskConfig("", []string{
+		"sh",
+		"-c",
+		"echo shared-ipc-ok > /dev/shm/marker && sleep 600",
+	})
+	mainTask := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "maintask",
+		AllocID:   allocId,
+		Resources: createBasicResources(),
+	}
+	must.NoError(t, mainTask.EncodeConcreteDriverConfig(&mainTaskCfg))
+
+	// sidecar joins the main task's IPC namespace and reads the marker
+	sidecarTaskCfg := newTaskConfig("", []string{
+		"sh",
+		"-c",
+		// give the main task a moment to write the marker
+		"sleep 2 && cat /dev/shm/marker",
+	})
+	sidecarTaskCfg.IPCMode = "task:maintask"
+	sidecarTask := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "sidecar",
+		AllocID:   allocId,
+		Resources: createBasicResources(),
+	}
+	must.NoError(t, sidecarTask.EncodeConcreteDriverConfig(&sidecarTaskCfg))
+
+	mainHarness := podmanDriverHarness(t, nil)
+	mainCleanup := mainHarness.MkAllocDir(mainTask, true)
+	defer mainCleanup()
+
+	_, _, err := mainHarness.StartTask(mainTask)
+	must.NoError(t, err)
+	defer func() {
+		_ = mainHarness.DestroyTask(mainTask.ID, true)
+	}()
+
+	// ensure the main task is running before the sidecar attempts to join
+	must.NoError(t, mainHarness.WaitUntilStarted(mainTask.ID, 20*time.Second))
+
+	sidecarHarness := podmanDriverHarness(t, nil)
+	sidecarCleanup := sidecarHarness.MkAllocDir(sidecarTask, true)
+	defer sidecarCleanup()
+
+	_, _, err = sidecarHarness.StartTask(sidecarTask)
+	must.NoError(t, err)
+	defer func() {
+		_ = sidecarHarness.DestroyTask(sidecarTask.ID, true)
+	}()
+
+	// Attempt to wait
+	waitCh, err := sidecarHarness.WaitTask(context.Background(), sidecarTask.ID)
+	must.NoError(t, err)
+
+	select {
+	case res := <-waitCh:
+		// should have a exitcode=0 result
+		must.True(t, res.Successful())
+	case <-time.After(15 * time.Second):
+		t.Fatalf("Sidecar did not exit in time")
+	}
+
+	// the marker is only visible if the sidecar shares the main task's
+	// IPC namespace (and therefore its /dev/shm)
+	tasklog := readStdoutLog(t, sidecarTask)
+	must.StrContains(t, tasklog, "shared-ipc-ok")
+}
+
+// check that combining shm_size with an ipc_mode that does not own the
+// container's /dev/shm is rejected by StartTask before the container is
+// created. Modes that own /dev/shm (private, shareable) are allowed and
+// covered separately.
+func TestPodmanDriver_IPCMode_ShmSizeConflict(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name    string
+		ipcMode string
+	}{
+		{name: "host", ipcMode: "host"},
+		{name: "none", ipcMode: "none"},
+		{name: "container", ipcMode: "container:somecontainer"},
+		{name: "ns", ipcMode: "ns:/proc/1/ns/ipc"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s_%s", t.Name(), tc.name), func(t *testing.T) {
+			taskCfg := newTaskConfig("", busyboxLongRunningCmd)
+			taskCfg.IPCMode = tc.ipcMode
+			taskCfg.ShmSize = "64m"
+
+			task := &drivers.TaskConfig{
+				ID:        uuid.Generate(),
+				Name:      fmt.Sprintf("ipc_shm_conflict_%s", tc.name),
+				AllocID:   uuid.Generate(),
+				Resources: createBasicResources(),
+			}
+			must.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+			d := podmanDriverHarness(t, nil)
+			defer d.MkAllocDir(task, true)()
+
+			_, _, err := d.StartTask(task)
+			must.Error(t, err)
+			must.StrContains(t, err.Error(), "shm_size cannot be used with ipc_mode")
+
+			_ = d.DestroyTask(task.ID, true)
+		})
+	}
+}
+
 // test kill / signal support
 func TestPodmanDriver_SignalTask(t *testing.T) {
 	ci.Parallel(t)


### PR DESCRIPTION
[Issue](https://hashicorp.atlassian.net/browse/NMD-1582)

**_Summary_**

The Podman driver previously gave tasks no control over their IPC namespace — every container got Podman's default (a `private` namespace with its own `/dev/shm`). This makes it impossible for tasks in the same allocation to share IPC primitives / `/dev/shm`,

_**What's Chnaged**_

This PR exposes a new optional `ipc_mode` task config option that maps directly to Podman's `--ipc`, bringing the driver to parity with the Docker driver's ipc_mode. It also adds a fail-fast conflict check between `ipc_mode `and `shm_size`.

- `StartTask` translates `ipc_mode` into createOpts.ContainerStorageConfig.IpcNS (driver.go), mirroring the existing 
`network_mode` handling (including the container:, ns:, and task: prefix forms via `BuildContainerNameForTask`).
- `Conflict check`: `shm_size` is now rejected with any `ipc_mode` that does not own the container's` /dev/shm` (i.e. anything other than `private/shareable`), matching the Podman API contract.

**_Example_**
```
config {
  ipc_mode = "task:mps-daemon"
} 
```

**_Supported values_**

ipc_mode | Behavior
-- | --
(unset) | Podman default — private namespace (unchanged)
host | use the host's IPC namespace (insecure)
private | private IPC namespace
shareable | private namespace other containers may join
none | private namespace with no /dev/shm mounted
`container:<id>` | join another container's IPC namespace
`ns:<path>` | join the IPC namespace at a path
`task:<name>` | join another task's IPC namespace in the same alloc (MPS pattern)

**_Before/After_**

Scenario | Before | After
-- | -- | --
ipc_mode in task config | unknown key → task fails to start (Invalid label: No argument or block type is named "ipc_mode") | accepted and applied
Default behavior (no ipc_mode) | private namespace | unchanged — private namespace
Two tasks sharing /dev/shm | not possible | ipc_mode = "task:<other>" → shared
--ipc=host etc. | not configurable | podman inspect ... HostConfig.IpcMode = host
shm_size + ipc_mode=host | n/a | fails fast: shm_size cannot be used with ipc_mode="host"; it requires a private or shareable IPC namespace

**_Testing_**
<details>

- Job files
1) ipc_share_task.nomad.hcl
```
job "ipc-share-task" {
  datacenters = ["dc1"]
  type        = "batch"

  group "mps-like" {
    # writer plays the role of the MPS control daemon
    task "writer" {
      driver = "podman"

      lifecycle {
        hook    = "prestart"
        sidecar = true
      }

      config {
        image   = "docker://busybox"
        command = "sh"
        args    = ["-c", "echo SHARED_OK > /dev/shm/marker && sleep 600"]
      }
    }

    # reader plays the role of an MPS client joining the daemon's IPC namespace
    task "reader" {
      driver = "podman"

      config {
        image   = "docker://busybox"
        command = "sh"
        args    = ["-c", "sleep 3; cat /dev/shm/marker 2>/dev/null || echo NOT_SHARED"]

        # the new option under test: join the writer task's IPC namespace
        ipc_mode = "task:writer"
      }
    }
  }
} 
```

2) ipc_host.nomad.hcl
```
job "ipc-host" {
  datacenters = ["dc1"]
  type        = "batch"

  group "ipc" {
    task "show-ipc" {
      driver = "podman"

      config {
        image   = "docker://busybox"
        command = "sh"
        args    = ["-c", "echo 'ipc ns:'; ls -l /proc/self/ns/ipc; echo done"]

        # the new option under test
        ipc_mode = "host"
      }
    }
  }
}
```

3) ipc_conflict.nomad.hcl
```
job "ipc-conflict" {
  datacenters = ["dc1"]
  type        = "batch"

  group "ipc" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    task "bad" {
      driver = "podman"

      config {
        image   = "docker://busybox"
        command = "sh"
        args    = ["-c", "echo should-not-start"]

        # invalid combination under test
        ipc_mode = "host"
        shm_size = "64m"
      }
    }
  }
}
```

-  **Before flow**:
```
2026-06-15T15:40:28.211+0530 [ERROR] client.alloc_runner.task_runner: running driver failed: alloc_id=d02db3b2-c06a-622f-5cbd-e88aa8903bab task=show-ipc
  error=
  | 2 errors occurred:
  | \t* failed to parse config: 
  | \t* Invalid label: No argument or block type is named "ipc_mode". 
```

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman$ ALLOC=$(nomad job allocs -json ipc-share-default | jq -r '.[0].ID')
sleep 6
nomad alloc logs -task reader "$ALLOC"
2026-06-15T15:47:30.379517994+05:30 stdout  F NOT_SHARED
```

- **Current Flow:**
1) for ipc_share_task.nomad.hcl
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman$ nomad job run examples/jobs/ipc/ipc_share_task.nomad.hcl
ALLOC=$(nomad job allocs -json ipc-share-task | jq -r '.[0].ID')
sleep 6
nomad alloc logs -task reader "$ALLOC"
==> 2026-06-15T15:58:01+05:30: Monitoring evaluation "6614d175"
    2026-06-15T15:58:01+05:30: Evaluation triggered by job "ipc-share-task"
    2026-06-15T15:58:02+05:30: Allocation "32baf8c1" created: node "b3fb2afe", group "mps-like"
    2026-06-15T15:58:02+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-06-15T15:58:02+05:30: Evaluation "6614d175" finished with status "complete"
2026-06-15T15:58:04.841193225+05:30 stdout F SHARED_OK
```

2) ipc_host.nomad.hcl
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman$ nomad job run examples/jobs/ipc/ipc_host.nomad.hcl
CID=$(podman ps -a --filter "name=show-ipc" --format '{{.ID}}' | head -1)
podman inspect "$CID" -f '{{.HostConfig.IpcMode}}'
==> 2026-06-15T15:56:19+05:30: Monitoring evaluation "7363bcf6"
    2026-06-15T15:56:19+05:30: Evaluation triggered by job "ipc-host"
    2026-06-15T15:56:20+05:30: Allocation "9ac47692" created: node "b3fb2afe", group "ipc"
    2026-06-15T15:56:20+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-06-15T15:56:20+05:30: Evaluation "7363bcf6" finished with status "complete"
host
```

3) ipc_conflict.nomad.hcl
```
2026-06-15T15:59:29.222+0530 [ERROR] client.alloc_runner.task_runner: running driver failed: alloc_id=98d02c88-5b5a-30c6-ec4b-d2e8fb27ab53 task=bad error="rpc error: code = Unknown desc = shm_size cannot be used with ipc_mode=\"host\"; it requires a private or shareable IPC namespace"
```



</details>




<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

