### PR TITLE
support http(s) URLs for oci-archive/docker-archive images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 IMPROVEMENTS:
+* driver: Adds support for loading `oci-archive` and `docker-archive` images from `http(s)` URLs. [[GH-517](https://github.com/hashicorp/nomad-driver-podman/pull/517)]
 * config: Adds support for plugin configuration `networking.default_rootless_mode` to override the default networking mode when run rootlessly. [[GH-495](https://github.com/hashicorp/nomad-driver-podman/pull/495)]
 * config: Support custom Podman network names for static IP/MAC options via `network_mode`. [[GH-509](https://github.com/hashicorp/nomad-driver-podman/pull/509)]
 * config: Added support for `os`, `arch` and `variant` task config options to override the platform of the image to pull. [[GH-514](https://github.com/hashicorp/nomad-driver-podman/pull/514)]

--- a/README.md
+++ b/README.md
@@ -224,11 +224,18 @@ plugin "nomad-driver-podman" {
 
 ## Task Configuration
 
-* **image** - The image to run. Accepted transports are `docker` (default if missing), `oci-archive` and `docker-archive`. Images reference as [short-names](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md#short-name-aliasing) will be treated according to user-configured preferences.
+* **image** - The image to run. Accepted transports are `docker` (default if missing), `oci-archive` and `docker-archive`. Images reference as [short-names](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md#short-name-aliasing) will be treated according to user-configured preferences. The `oci-archive` and `docker-archive` transports also accept an `http(s)://` URL; the archive is downloaded (bounded by `image_pull_timeout`) and loaded into Podman.
 
 ```hcl
 config {
   image = "docker://redis"
+}
+```
+
+```hcl
+config {
+  # Load an image archive served over HTTP.
+  image = "oci-archive:https://example.com/images/redis.tar"
 }
 ```
 

--- a/api/image_inspect.go
+++ b/api/image_inspect.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/image_load.go
+++ b/api/image_load.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/image_load.go
+++ b/api/image_load.go
@@ -16,13 +16,21 @@ type imageLoadResponse struct {
 	Names []string `json:"Names"`
 }
 
-// ImageLoad uploads a tar archive as an image
+// ImageLoad uploads a tar archive on the local filesystem as an image.
 func (c *API) ImageLoad(ctx context.Context, path string) (string, error) {
 	archive, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
 	defer ignoreClose(archive)
+	return c.ImageLoadReader(ctx, archive)
+}
+
+// ImageLoadReader uploads a tar archive read from archive as an image. The
+// caller is responsible for closing archive. This allows loading an archive
+// from any source (e.g. a local file or an HTTP response body) without first
+// staging it on disk.
+func (c *API) ImageLoadReader(ctx context.Context, archive io.Reader) (string, error) {
 	response := imageLoadResponse{}
 
 	res, err := c.Post(ctx, "/v1.0.0/libpod/images/load", archive)

--- a/api/image_pull.go
+++ b/api/image_pull.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/driver.go
+++ b/driver.go
@@ -52,6 +52,11 @@ const (
 	// fingerprintPeriod is the interval at which the driver will send fingerprint responses
 	fingerprintPeriod = 30 * time.Second
 
+	// defaultHTTPTimeout bounds requests made by the driver's httpClient when
+	// downloading image archives from an http(s) URL. It matches the 60s used
+	// by the podman api client.
+	defaultHTTPTimeout = 60 * time.Second
+
 	// taskHandleVersion is the version of task handle which this driver sets
 	// and understands how to decode driver state
 	taskHandleVersion = 1
@@ -158,7 +163,7 @@ func NewPodmanDriver(logger hclog.Logger) drivers.DriverPlugin {
 		ctx:            ctx,
 		signalShutdown: cancel,
 		logger:         logger.Named(pluginName),
-		httpClient:     &http.Client{},
+		httpClient:     &http.Client{Timeout: defaultHTTPTimeout},
 	}
 }
 

--- a/driver.go
+++ b/driver.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1263,9 +1264,20 @@ func (d *Driver) createImage(
 	var imageID string
 	imageName := image
 	loadedFromArchive := false
-	// If it is a shortname, we should not have to worry
-	// Let podman deal with it according to user configuration
-	if !shortnames.IsShortName(image) {
+	// Archive transports (oci-archive/docker-archive) pointing at an http(s)
+	// URL are handled here because the upstream containers/image reference
+	// parsers reject a URL in place of a local path. The archive is streamed
+	// straight to podman's load endpoint without staging it on disk.
+	if archiveURL, ok := archiveTransportURL(image); ok {
+		loadedName, err := d.loadImageFromURL(archiveURL, podmanClient, imagePullTimeout, cfg)
+		if err != nil {
+			return imageID, err
+		}
+		imageName = loadedName
+		loadedFromArchive = true
+	} else if !shortnames.IsShortName(image) {
+		// If it is a shortname, we should not have to worry
+		// Let podman deal with it according to user configuration
 		imageRef, err := parseImage(image)
 		if err != nil {
 			return imageID, fmt.Errorf("invalid image reference %s: %w", image, err)
@@ -1280,13 +1292,7 @@ func (d *Driver) createImage(
 			archiveData := imageRef.StringWithinTransport()
 			path := strings.Split(archiveData, ":")[0]
 			d.logger.Debug("Load image archive", "path", path)
-			_ = d.eventer.EmitEvent(&drivers.TaskEvent{
-				TaskID:    cfg.ID,
-				TaskName:  cfg.Name,
-				AllocID:   cfg.AllocID,
-				Timestamp: time.Now(),
-				Message:   "Loading image " + path,
-			})
+			d.emitImageEvent(cfg, "Loading image "+path)
 			imageName, err = podmanClient.ImageLoad(d.ctx, path)
 			if err != nil {
 				return imageID, fmt.Errorf("error while loading image: %w", err)
@@ -1315,13 +1321,7 @@ func (d *Driver) createImage(
 
 	d.logger.Info("Pulling image", "image", imageName)
 
-	_ = d.eventer.EmitEvent(&drivers.TaskEvent{
-		TaskID:    cfg.ID,
-		TaskName:  cfg.Name,
-		AllocID:   cfg.AllocID,
-		Timestamp: time.Now(),
-		Message:   "Pulling image " + imageName,
-	})
+	d.emitImageEvent(cfg, "Pulling image "+imageName)
 
 	pc := &registry.PullConfig{
 		Image:     imageName,
@@ -1367,6 +1367,75 @@ func (d *Driver) createImage(
 	imageID = result.(string)
 	d.logger.Debug("Pulled image ID", "imageID", imageID)
 	return imageID, nil
+}
+
+// emitImageEvent broadcasts a task event for an image operation (loading or
+// pulling), filling in the task identity fields shared by every such event.
+func (d *Driver) emitImageEvent(cfg *drivers.TaskConfig, message string) {
+	_ = d.eventer.EmitEvent(&drivers.TaskEvent{
+		TaskID:    cfg.ID,
+		TaskName:  cfg.Name,
+		AllocID:   cfg.AllocID,
+		Timestamp: time.Now(),
+		Message:   message,
+	})
+}
+
+// loadImageFromURL downloads an image archive from an http(s) URL and streams
+// it directly to podman's image load endpoint. The download is bounded by
+// imagePullTimeout and the archive is never staged on local disk. It returns
+// the name of the loaded image.
+func (d *Driver) loadImageFromURL(
+	url string,
+	podmanClient *api.API,
+	imagePullTimeout time.Duration,
+	cfg *drivers.TaskConfig,
+) (string, error) {
+	d.logger.Debug("Downloading image archive", "url", url)
+	d.emitImageEvent(cfg, "Loading image "+url)
+
+	ctx, cancel := context.WithTimeout(d.ctx, imagePullTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build request for image archive %s: %w", url, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to download image archive %s: %w", url, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download image archive %s: unexpected status %s", url, resp.Status)
+	}
+
+	imageName, err := podmanClient.ImageLoadReader(ctx, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error while loading image: %w", err)
+	}
+	
+	return imageName, nil
+}
+
+// archiveTransportURL detects an oci-archive or docker-archive image reference
+// whose archive is located at an http(s) URL, e.g.
+// "oci-archive:http://host:9999/image.tar". The upstream containers/image
+// reference parsers cannot handle a URL in place of a local path, so these
+// references must be intercepted before parseImage. It returns the URL and true
+// when the reference matches, and "", false otherwise.
+func archiveTransportURL(image string) (string, bool) {
+	for _, transport := range []string{"oci-archive:", "docker-archive:"} {
+		if rest, ok := strings.CutPrefix(image, transport); ok {
+			if strings.HasPrefix(rest, "http://") || strings.HasPrefix(rest, "https://") {
+				return rest, true
+			}
+		}
+	}
+	return "", false
 }
 
 func parseImage(image string) (types.ImageReference, error) {

--- a/driver.go
+++ b/driver.go
@@ -1417,7 +1417,7 @@ func (d *Driver) loadImageFromURL(
 	if err != nil {
 		return "", fmt.Errorf("error while loading image: %w", err)
 	}
-	
+
 	return imageName, nil
 }
 

--- a/driver.go
+++ b/driver.go
@@ -128,6 +128,11 @@ type Driver struct {
 	// For any call where it's unspecified/unknown which podman should be used
 	defaultPodman *api.API
 
+	// httpClient is used to download image archives referenced by an http(s)
+	// URL. It is kept on the driver so request behaviour is configured in one
+	// place rather than relying on http.DefaultClient.
+	httpClient *http.Client
+
 	// singleflight group to prevent parallel image downloads
 	pullGroup singleflight.Group
 }
@@ -153,6 +158,7 @@ func NewPodmanDriver(logger hclog.Logger) drivers.DriverPlugin {
 		ctx:            ctx,
 		signalShutdown: cancel,
 		logger:         logger.Named(pluginName),
+		httpClient:     &http.Client{},
 	}
 }
 
@@ -1397,21 +1403,11 @@ func (d *Driver) loadImageFromURL(
 	ctx, cancel := context.WithTimeout(d.ctx, imagePullTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	resp, err := d.getImageArchive(ctx, url)
 	if err != nil {
-		return "", fmt.Errorf("failed to build request for image archive %s: %w", url, err)
+		return "", err
 	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to download image archive %s: %w", url, err)
-	}
-
 	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to download image archive %s: unexpected status %s", url, resp.Status)
-	}
 
 	imageName, err := podmanClient.ImageLoadReader(ctx, resp.Body)
 	if err != nil {
@@ -1419,6 +1415,30 @@ func (d *Driver) loadImageFromURL(
 	}
 
 	return imageName, nil
+}
+
+// getImageArchive issues the GET request for an image archive using the
+// driver's http client and returns the response on success. It encapsulates the
+// request boilerplate (building the request, performing it, and validating the
+// status) so the load logic stays separate from the transport concerns. The
+// caller is responsible for closing the response body.
+func (d *Driver) getImageArchive(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request for image archive %s: %w", url, err)
+	}
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download image archive %s: %w", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("failed to download image archive %s: unexpected status %s", url, resp.Status)
+	}
+
+	return resp, nil
 }
 
 // archiveTransportURL detects an oci-archive or docker-archive image reference

--- a/driver_test.go
+++ b/driver_test.go
@@ -2440,6 +2440,51 @@ func createInspectImage(t *testing.T, image, reference string) {
 	must.Eq(t, idRef, idTest)
 }
 
+func Test_createImageArchivesHTTP(t *testing.T) {
+	ci.Parallel(t)
+
+	doesNotExist := func(filepath string) bool {
+		_, err := os.Stat(filepath)
+		if errors.Is(err, os.ErrNotExist) {
+			return true
+		}
+		must.NoError(t, err)
+		return false
+	}
+
+	if doesNotExist("/tmp/oci-archive") || doesNotExist("/tmp/docker-archive") {
+		t.Skip("Skipping image archive test. Missing prepared archive file(s).")
+	}
+
+	archiveDir := os.Getenv("ARCHIVE_DIR")
+	if archiveDir == "" {
+		t.Skip("Skipping image archive test. Missing \"ARCHIVE_DIR\" environment variable")
+	}
+
+	// Serve the prepared archive files over HTTP so createImage exercises the
+	// download-then-load path instead of reading from disk.
+	server := httptest.NewServer(http.FileServer(http.Dir(archiveDir)))
+	t.Cleanup(server.Close)
+
+	testCases := []struct {
+		Image     string
+		Reference string
+	}{
+		{
+			Image:     fmt.Sprintf("oci-archive:%s/oci-archive", server.URL),
+			Reference: "docker.io/library/alpine:latest",
+		},
+		{
+			Image:     fmt.Sprintf("docker-archive:%s/docker-archive", server.URL),
+			Reference: "docker.io/library/alpine:latest",
+		},
+	}
+
+	for _, testCase := range testCases {
+		createInspectImage(t, testCase.Image, testCase.Reference)
+	}
+}
+
 func createInspectImagePlatform(t *testing.T, image string, platform imagePlatform) string {
 	d := podmanDriverHarness(t, nil)
 
@@ -2697,6 +2742,83 @@ func Test_parseImage(t *testing.T) {
 		}
 
 	}
+}
+
+func Test_archiveTransportURL(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		Name    string
+		Input   string
+		WantURL string
+		WantOK  bool
+	}{
+		{
+			Name:    "oci-archive http",
+			Input:   "oci-archive:http://10.211.55.9:9999/uploads/myhttp.tar",
+			WantURL: "http://10.211.55.9:9999/uploads/myhttp.tar",
+			WantOK:  true,
+		},
+		{
+			Name:    "oci-archive https",
+			Input:   "oci-archive:https://example.com/image.tar",
+			WantURL: "https://example.com/image.tar",
+			WantOK:  true,
+		},
+		{
+			Name:    "docker-archive http",
+			Input:   "docker-archive:http://example.com/image.tar",
+			WantURL: "http://example.com/image.tar",
+			WantOK:  true,
+		},
+		{
+			Name:   "docker-archive local path with tag",
+			Input:  "docker-archive:/tmp/image.tar:latest",
+			WantOK: false,
+		},
+		{
+			Name:   "docker transport url",
+			Input:  "docker://quay.io/repo/busybox:latest",
+			WantOK: false,
+		},
+		{
+			Name:   "plain image name",
+			Input:  "busybox:latest",
+			WantOK: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			gotURL, gotOK := archiveTransportURL(testCase.Input)
+			must.Eq(t, testCase.WantOK, gotOK)
+			must.Eq(t, testCase.WantURL, gotURL)
+		})
+	}
+}
+
+// Test_loadImageFromURL_httpError verifies that a non-200 response from the
+// archive URL produces a clear error before any podman interaction.
+func Test_loadImageFromURL_httpError(t *testing.T) {
+	ci.Parallel(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no such archive", http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	driver, ok := NewPodmanDriver(testlog.HCLogger(t)).(*Driver)
+	must.True(t, ok)
+
+	task := &drivers.TaskConfig{
+		ID:      uuid.Generate(),
+		Name:    "loadImageFromURL",
+		AllocID: uuid.Generate(),
+	}
+
+	_, err := driver.loadImageFromURL(server.URL+"/missing.tar", nil, time.Minute, task)
+	must.ErrorContains(t, err, "404")
+	must.ErrorContains(t, err, "unexpected status")
 }
 
 func Test_namedSocketIsDefault(t *testing.T) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -2345,7 +2345,24 @@ func Test_createImage(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		createInspectImage(t, testCase.Image, testCase.Reference)
+		t.Run(testCase.Image, func(t *testing.T) {
+			d := podmanDriverHarness(t, nil)
+			driver := getPodmanDriver(t, d)
+
+			task := &drivers.TaskConfig{
+				ID:        uuid.Generate(),
+				Name:      "inspectImage",
+				AllocID:   uuid.Generate(),
+				Resources: createBasicResources(),
+			}
+
+			idTest, err := driver.createImage(testCase.Image, &TaskAuthConfig{}, false, false, imagePlatform{}, driver.defaultPodman, 5*time.Minute, task)
+			must.NoError(t, err)
+
+			idRef, err := driver.defaultPodman.ImageInspectID(context.Background(), testCase.Reference)
+			must.NoError(t, err)
+			must.Eq(t, idRef, idTest)
+		})
 	}
 }
 
@@ -2394,13 +2411,15 @@ func Test_createImageArchives(t *testing.T) {
 		return false
 	}
 
-	if doesNotExist("/tmp/oci-archive") || doesNotExist("/tmp/docker-archive") {
-		t.Skip("Skipping image archive test. Missing prepared archive file(s).")
-	}
-
+	// Archives are prepared by .github/machinesetup.sh in /tmp; ARCHIVE_DIR can
+	// override the location for local runs.
 	archiveDir := os.Getenv("ARCHIVE_DIR")
 	if archiveDir == "" {
-		t.Skip("Skipping image archive test. Missing \"ARCHIVE_DIR\" environment variable")
+		archiveDir = "/tmp"
+	}
+
+	if doesNotExist(archiveDir+"/oci-archive") || doesNotExist(archiveDir+"/docker-archive") {
+		t.Skip("Skipping image archive test. Missing prepared archive file(s).")
 	}
 
 	testCases := []struct {
@@ -2409,35 +2428,34 @@ func Test_createImageArchives(t *testing.T) {
 	}{
 		{
 			Image:     fmt.Sprintf("oci-archive:%s/oci-archive", archiveDir),
-			Reference: "docker.io/library/alpine:latest",
+			Reference: "docker.io/library/alpine:3",
 		},
 		{
 			Image:     fmt.Sprintf("docker-archive:%s/docker-archive", archiveDir),
-			Reference: "docker.io/library/alpine:latest",
+			Reference: "docker.io/library/alpine:3",
 		},
 	}
 
 	for _, testCase := range testCases {
-		createInspectImage(t, testCase.Image, testCase.Reference)
+		t.Run(testCase.Image, func(t *testing.T) {
+			d := podmanDriverHarness(t, nil)
+			driver := getPodmanDriver(t, d)
+
+			task := &drivers.TaskConfig{
+				ID:        uuid.Generate(),
+				Name:      "inspectImage",
+				AllocID:   uuid.Generate(),
+				Resources: createBasicResources(),
+			}
+
+			idTest, err := driver.createImage(testCase.Image, &TaskAuthConfig{}, false, false, imagePlatform{}, driver.defaultPodman, 5*time.Minute, task)
+			must.NoError(t, err)
+
+			idRef, err := driver.defaultPodman.ImageInspectID(context.Background(), testCase.Reference)
+			must.NoError(t, err)
+			must.Eq(t, idRef, idTest)
+		})
 	}
-}
-
-func createInspectImage(t *testing.T, image, reference string) {
-	d := podmanDriverHarness(t, nil)
-
-	task := &drivers.TaskConfig{
-		ID:        uuid.Generate(),
-		Name:      "inspectImage",
-		AllocID:   uuid.Generate(),
-		Resources: createBasicResources(),
-	}
-	driver := getPodmanDriver(t, d)
-	idTest, err := driver.createImage(image, &TaskAuthConfig{}, false, false, imagePlatform{}, driver.defaultPodman, 5*time.Minute, task)
-	must.NoError(t, err)
-
-	idRef, err := driver.defaultPodman.ImageInspectID(context.Background(), reference)
-	must.NoError(t, err)
-	must.Eq(t, idRef, idTest)
 }
 
 func Test_createImageArchivesHTTP(t *testing.T) {
@@ -2452,13 +2470,15 @@ func Test_createImageArchivesHTTP(t *testing.T) {
 		return false
 	}
 
-	if doesNotExist("/tmp/oci-archive") || doesNotExist("/tmp/docker-archive") {
-		t.Skip("Skipping image archive test. Missing prepared archive file(s).")
-	}
-
+	// Archives are prepared by .github/machinesetup.sh in /tmp; ARCHIVE_DIR can
+	// override the location for local runs.
 	archiveDir := os.Getenv("ARCHIVE_DIR")
 	if archiveDir == "" {
-		t.Skip("Skipping image archive test. Missing \"ARCHIVE_DIR\" environment variable")
+		archiveDir = "/tmp"
+	}
+
+	if doesNotExist(archiveDir+"/oci-archive") || doesNotExist(archiveDir+"/docker-archive") {
+		t.Skip("Skipping image archive test. Missing prepared archive file(s).")
 	}
 
 	// Serve the prepared archive files over HTTP so createImage exercises the
@@ -2472,16 +2492,33 @@ func Test_createImageArchivesHTTP(t *testing.T) {
 	}{
 		{
 			Image:     fmt.Sprintf("oci-archive:%s/oci-archive", server.URL),
-			Reference: "docker.io/library/alpine:latest",
+			Reference: "docker.io/library/alpine:3",
 		},
 		{
 			Image:     fmt.Sprintf("docker-archive:%s/docker-archive", server.URL),
-			Reference: "docker.io/library/alpine:latest",
+			Reference: "docker.io/library/alpine:3",
 		},
 	}
 
 	for _, testCase := range testCases {
-		createInspectImage(t, testCase.Image, testCase.Reference)
+		t.Run(testCase.Image, func(t *testing.T) {
+			d := podmanDriverHarness(t, nil)
+			driver := getPodmanDriver(t, d)
+
+			task := &drivers.TaskConfig{
+				ID:        uuid.Generate(),
+				Name:      "inspectImage",
+				AllocID:   uuid.Generate(),
+				Resources: createBasicResources(),
+			}
+
+			idTest, err := driver.createImage(testCase.Image, &TaskAuthConfig{}, false, false, imagePlatform{}, driver.defaultPodman, 5*time.Minute, task)
+			must.NoError(t, err)
+
+			idRef, err := driver.defaultPodman.ImageInspectID(context.Background(), testCase.Reference)
+			must.NoError(t, err)
+			must.Eq(t, idRef, idTest)
+		})
 	}
 }
 

--- a/registry/authentication.go
+++ b/registry/authentication.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package registry


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-podman/issues/434

[Issue](https://hashicorp.atlassian.net/browse/NMD-1000)

**_Summary_**

The podman driver lets you run an image straight from a tar archive using the `oci-archive: `and `docker-archive:` transports. Previously this only worked for archives on the `local filesystem`. This PR lets the archive also live behind an `http://` or `https://` URL, so a job can pull a one-off image from a web server, object store, or artifact registry.

_**Fix**_ 

Detect archive references that point at an `http(s)` URL before they reach the path-only parser, and handle them on a dedicated path:

- Recognized `oci-archive: / docker-archive: + http(s)://` .
- Downloaded the URL (bounded by the task's image_pull_timeout and cancelled on driver shutdown).
- Stream the response directly into podman's image-load endpoint — no temp file, no extra disk usage, no cleanup.
- Surfaced a clear, early error on a bad URL (e.g. a 404) instead of feeding garbage to podman.

All existing paths (registry pulls, local archives, short names) are untouched.

Example job config:

```
config {
  image = "oci-archive:https://artifacts.example.com/images/myapp.tar"
  # docker-archive works the same way:
  # image = "docker-archive:https://artifacts.example.com/images/myapp.tar"
}
```

**_Before/ After Flow_**

Step | Before | After
-- | -- | --
Reference detected | Sent to path-only parser | URL form intercepted first
URL parsing | Invalid image //host:port/... | recognized as a download target
Download | Never attempted | GET the URL (timeout-bound, cancellable)
Bad URL (e.g. 404) |  confusing parse error | unexpected status 404 ..., fails early
Load into podman | n/a (never reached) | Response body streamed straight to load endpoint (no temp file)
Result |  task never starts |  image loaded, task runs

**Testing**
<details>

**After Fix:** 

-> **job-http-archive.nomad.hcl**

```
job "http-archive" {
  type = "batch"

  group "demo" {
    task "myhttp" {
      driver = "podman"

      config {
        image   = "oci-archive:http://127.0.0.1:9999/myhttp.tar"
        command = "sh"
        args    = ["-c", "echo loaded-from-oci-http-OK && sleep 20"]
      }

      resources {
        cpu    = 100
        memory = 64
      }
    }
  }
}
```
**Result:**

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman/test/e2e/oci-archive-http$ nomad alloc status cde66313
ID                  = cde66313-7a6c-6e4b-870c-9d39d71f5d3e
Eval ID             = efabd825
Name                = http-archive.demo[0]
Node ID             = 0ab78424
Node Name           = podman-dev
Job ID              = http-archive
Job Version         = 0
Client Status       = complete
Client Description  = All tasks have completed
Desired Status      = run
Desired Description = <none>
Created             = 37s ago
Modified            = 12s ago

Task "myhttp" is "dead"
Task Resources:
CPU        Memory         Disk     Addresses
0/100 MHz  44 KiB/64 MiB  300 MiB  

Task Events:
Started At     = 2026-06-24T07:10:47Z
Finished At    = 2026-06-24T07:11:09Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2026-06-24T12:41:09+05:30  Terminated  Exit Code: 0
2026-06-24T12:40:47+05:30  Started     Task started by client
2026-06-24T12:40:47+05:30  Driver      Loading image http://127.0.0.1:9999/myhttp.tar
2026-06-24T12:40:47+05:30  Task Setup  Building Task Directory
2026-06-24T12:40:47+05:30  Received    Task received by client

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman/test/e2e/oci-archive-http$ nomad alloc logs cde66313
2026-06-24T12:40:47.966599307+05:30 stdout F loaded-from-oci-http-OK
```

-> **job-http-archive-404.nomad.hcl**
```
job "http-archive-404" {
  type = "batch"

  group "demo" {
    task "myhttp" {
      driver = "podman"

      config {
        image   = "oci-archive:http://127.0.0.1:9999/does-not-exist.tar"
        command = "sh"
        args    = ["-c", "echo should-not-run"]
      }

      resources {
        cpu    = 100
        memory = 64
      }
    }
  }
}
```

**Result:**
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman/test/e2e/oci-archive-http$ nomad alloc status b8814f10 
ID                  = b8814f10-868d-34af-01c4-8c3ea8d6c0e0
Eval ID             = 9f8ab5d6
Name                = http-archive-404.demo[0]
Node ID             = 17dc491f
Node Name           = podman-dev
Job ID              = http-archive-404
Job Version         = 0
Client Status       = failed
Client Description  = Failed tasks
Desired Status      = run
Desired Description = <none>
Created             = 38s ago
Modified            = 34s ago
Reschedule Attempts = 1/1

Task "myhttp" is "dead"
Task Resources:
CPU      Memory  Disk     Addresses
100 MHz  64 MiB  300 MiB  

Task Events:
Started At     = N/A
Finished At    = 2026-06-24T07:40:02Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type            Description
2026-06-24T13:10:02+05:30  Not Restarting  Error was unrecoverable
2026-06-24T13:10:02+05:30  Driver Failure  rpc error: code = Unknown desc = failed to create image: oci-archive:http://127.0.0.1:9999/does-not-exist.tar: failed to download image archive http://127.0.0.1:9999/does-not-exist.tar: unexpected status 404 File not found
2026-06-24T13:10:02+05:30  Driver          Loading image http://127.0.0.1:9999/does-not-exist.tar
2026-06-24T13:10:02+05:30  Task Setup      Building Task Directory
2026-06-24T13:10:02+05:30  Received        Task received by client
```

-> **local-archive.nomad.hcl**
```
job "local-archive" {
  type = "batch"

  group "demo" {
    task "myhttp" {
      driver = "podman"

      config {
        image   = "oci-archive:/tmp/web/myhttp.tar"
        command = "sh"
        args    = ["-c", "echo loaded-from-local-oci-OK && sleep 20"]
      }

      resources {
        cpu    = 100
        memory = 64
      }
    }
  }
}
```

**Result:**
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman/test/e2e/oci-archive-http$ nomad job run jobs/local-archive.nomad.hcl
==> 2026-06-24T13:14:25+05:30: Monitoring evaluation "6c04c944"
    2026-06-24T13:14:25+05:30: Evaluation triggered by job "local-archive"
    2026-06-24T13:14:26+05:30: Allocation "3b1d4f4c" created: node "17dc491f", group "demo"
    2026-06-24T13:14:26+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-06-24T13:14:26+05:30: Evaluation "6c04c944" finished with status "complete"
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman/test/e2e/oci-archive-http$ nomad job status local-archive
ID            = local-archive
Name          = local-archive
Submit Date   = 2026-06-24T13:14:25+05:30
Type          = batch
Priority      = 50
Datacenters   = *
Namespace     = default
Node Pool     = default
Status        = running
Periodic      = false
Parameterized = false

Summary
Task Group  Queued  Starting  Running  Failed  Complete  Lost  Unknown
demo        0       0         1        0       0         0     0

Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
3b1d4f4c  17dc491f  demo        0        run      running  13s ago  12s ago
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman/test/e2e/oci-archive-http$ nomad alloc logs 3b1d4f4c
2026-06-24T13:14:25.742780422+05:30 stdout F loaded-from-local-oci-OK
```

**Before: tested for job  http-archive**
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-podman/test/e2e/oci-archive-http$ nomad alloc status 6b627a41
ID                   = 6b627a41-0bd3-4472-81a8-2cb6a83a4dfa
Eval ID              = c8d5dfb5
Name                 = http-archive.demo[0]
Node ID              = 66b37253
Node Name            = podman-dev
Job ID               = http-archive
Job Version          = 0
Client Status        = failed
Client Description   = Failed tasks
Desired Status       = stop
Desired Description  = alloc was rescheduled because it failed
Created              = 25s ago
Modified             = 20s ago
Replacement Alloc ID = 8d60257f

Task "myhttp" is "dead"
Task Resources:
CPU      Memory  Disk     Addresses
100 MHz  64 MiB  300 MiB  

Task Events:
Started At     = N/A
Finished At    = 2026-06-24T07:57:21Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type            Description
2026-06-24T13:27:21+05:30  Not Restarting  Error was unrecoverable
2026-06-24T13:27:21+05:30  Driver Failure  rpc error: code = Unknown desc = failed to create image: oci-archive:http://127.0.0.1:9999/myhttp.tar: invalid image reference oci-archive:http://127.0.0.1:9999/myhttp.tar: Invalid image //127.0.0.1:9999/myhttp.tar
2026-06-24T13:27:21+05:30  Task Setup      Building Task Directory
2026-06-24T13:27:21+05:30  Received        Task received by client
```



</details>




<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

