### PR TITLE
driver: separate lifecycle monitoring from stats

### DIFF
--- a/api/container_wait.go
+++ b/api/container_wait.go
@@ -10,10 +10,16 @@ import (
 	"strings"
 )
 
-// ContainerWait waits on a container to met a given condition
+// ContainerWait waits on a container to meet one of the given conditions.
+// It uses the streaming client because a container may run longer than the
+// regular API client timeout.
 func (c *API) ContainerWait(ctx context.Context, name string, conditions []string) error {
-
-	res, err := c.Post(ctx, fmt.Sprintf("/v1.0.0/libpod/containers/%s/wait?condition=%s", name, strings.Join(conditions, "&condition=")), nil)
+	path := fmt.Sprintf("/v1.0.0/libpod/containers/%s/wait?condition=%s", name, strings.Join(conditions, "&condition="))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseUrl+path, nil)
+	if err != nil {
+		return err
+	}
+	res, err := c.Do(req, true)
 	if err != nil {
 		return err
 	}

--- a/api/container_wait_test.go
+++ b/api/container_wait_test.go
@@ -1,0 +1,72 @@
+// Copyright IBM Corp. 2019, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestContainerWaitUsesStreamingClient(t *testing.T) {
+	var gotMethod string
+	var gotPath string
+	var gotConditions []string
+
+	client := &API{
+		baseUrl: "http://podman",
+		httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("regular HTTP client was used for a blocking wait request")
+			return nil, nil
+		})},
+		httpStreamClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			gotMethod = req.Method
+			gotPath = req.URL.Path
+			gotConditions = req.URL.Query()["condition"]
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("0")),
+				Header:     make(http.Header),
+			}, nil
+		})},
+	}
+
+	err := client.ContainerWait(context.Background(), "container-id", []string{"running", "exited"})
+	if err != nil {
+		t.Fatalf("ContainerWait returned an error: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q; want %q", gotMethod, http.MethodPost)
+	}
+	if gotPath != "/v1.0.0/libpod/containers/container-id/wait" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if len(gotConditions) != 2 || gotConditions[0] != "running" || gotConditions[1] != "exited" {
+		t.Fatalf("conditions = %#v", gotConditions)
+	}
+}
+
+func TestContainerWaitPropagatesStreamingError(t *testing.T) {
+	wantErr := errors.New("stream disconnected")
+	client := &API{
+		baseUrl: "http://podman",
+		httpStreamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, wantErr
+		})},
+	}
+
+	err := client.ContainerWait(context.Background(), "container-id", []string{"exited"})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v; want %v", err, wantErr)
+	}
+}

--- a/driver.go
+++ b/driver.go
@@ -474,7 +474,6 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 		logger:                d.logger.Named(fmt.Sprintf("podman.%s", podmanTaskSocketName)),
 		logPointer:            time.Now(), // do not rewind log to the startetAt date.
 		logStreamer:           taskState.LogStreamer,
-		collectionInterval:    time.Second,
 		totalCPUStats:         cpustats.New(d.compute),
 		userCPUStats:          cpustats.New(d.compute),
 		systemCPUStats:        cpustats.New(d.compute),
@@ -511,6 +510,7 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 	d.tasks.Set(handle.Config.ID, h)
 
 	go h.runContainerMonitor()
+	go h.runStatsMonitor()
 	d.logger.Debug("Recovered container handle", "container", taskState.ContainerID, "podman client", podmanTaskSocketName)
 
 	return nil
@@ -1067,7 +1067,6 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		logger:                d.logger.Named(fmt.Sprintf("podman.%s", podmanTaskSocketName)),
 		logStreamer:           createOpts.LogConfiguration.Driver == LOG_DRIVER_JOURNALD,
 		logPointer:            time.Now(),
-		collectionInterval:    time.Second,
 		totalCPUStats:         cpustats.New(d.compute),
 		userCPUStats:          cpustats.New(d.compute),
 		systemCPUStats:        cpustats.New(d.compute),
@@ -1132,6 +1131,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	d.tasks.Set(cfg.ID, h)
 
 	go h.runContainerMonitor()
+	go h.runStatsMonitor()
 
 	d.logger.Info("Completely started container", "taskID", cfg.ID, "container", containerID, "ip", containerIP)
 
@@ -1597,7 +1597,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 		if err != nil {
 			d.logger.Warn("failed to stop/kill container during destroy", "error", err)
 		}
-		// wait a while for stats emitter to collect exit code etc.
+		// Wait for the lifecycle monitor to collect the exit code and final state.
 		for i := 0; i < 20; i++ {
 			if !handle.isRunning() {
 				break
@@ -1605,7 +1605,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 			time.Sleep(time.Millisecond * 250)
 		}
 		if handle.isRunning() {
-			d.logger.Warn("stats emitter did not exit while stop/kill container during destroy", "error", err)
+			d.logger.Warn("lifecycle monitor did not observe container exit during destroy", "error", err)
 		}
 	}
 

--- a/handle.go
+++ b/handle.go
@@ -23,6 +23,20 @@ var (
 	measuredMemStats = []string{"Usage", "Max Usage"}
 )
 
+const (
+	containerMonitorRetryInterval = time.Second
+	containerStatsPollInterval    = time.Second
+)
+
+type containerLifecycleClient interface {
+	ContainerInspect(context.Context, string) (api.InspectContainerData, error)
+	ContainerWait(context.Context, string, []string) error
+}
+
+type containerStatsClient interface {
+	ContainerStats(context.Context, string) (api.Stats, error)
+}
+
 // TaskHandle is the podman specific handle for exactly one container
 type TaskHandle struct {
 	containerID  string
@@ -33,8 +47,6 @@ type TaskHandle struct {
 	totalCPUStats  *cpustats.Tracker
 	userCPUStats   *cpustats.Tracker
 	systemCPUStats *cpustats.Tracker
-
-	collectionInterval time.Duration
 
 	// stateLock syncs access to all fields below
 	stateLock sync.RWMutex
@@ -103,8 +115,9 @@ func (h *TaskHandle) runExitWatcher(ctx context.Context, exitChannel chan *drive
 
 func (h *TaskHandle) runStatsEmitter(ctx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
 	timer := time.NewTimer(0)
+	defer timer.Stop()
+	defer close(statsChannel)
 	h.logger.Debug("Starting statsEmitter", "container", h.containerID)
-	h.collectionInterval = interval
 	for {
 		select {
 		case <-ctx.Done():
@@ -112,6 +125,10 @@ func (h *TaskHandle) runStatsEmitter(ctx context.Context, statsChannel chan *dri
 			return
 		case <-timer.C:
 			timer.Reset(interval)
+		}
+		if !h.isRunning() {
+			h.logger.Debug("Stopping statsEmitter for exited container", "container", h.containerID)
+			return
 		}
 
 		h.stateLock.Lock()
@@ -190,59 +207,34 @@ func (h *TaskHandle) runLogStreamer(ctx context.Context) {
 
 }
 
-func (h *TaskHandle) runContainerMonitor() {
+func (h *TaskHandle) runStatsMonitor() {
+	h.runStatsMonitorWithClient(h.driver.ctx, h.podmanClient, containerStatsPollInterval)
+}
 
-	timer := time.NewTimer(0)
-	h.logger.Debug("Monitoring container", "container", h.containerID)
+func (h *TaskHandle) runStatsMonitorWithClient(ctx context.Context, client containerStatsClient, interval time.Duration) {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	h.logger.Debug("Monitoring container stats", "container", h.containerID)
 
 	for {
 		select {
-		case <-h.driver.ctx.Done():
+		case <-ctx.Done():
 			return
 
 		case <-timer.C:
-			timer.Reset(h.collectionInterval)
+			timer.Reset(interval)
 		}
 
-		containerStats, statsErr := h.podmanClient.ContainerStats(h.driver.ctx, h.containerID)
-		if statsErr != nil {
-			gone := false
-			if errors.Is(statsErr, api.ContainerNotFound) {
-				gone = true
-			} else if errors.Is(statsErr, api.ContainerWrongState) {
-				gone = true
-			}
-			if gone {
-				h.logger.Debug("Container is not running anymore", "container", h.containerID, "error", statsErr)
-				// container was stopped, get exit code and other post mortem infos
-				inspectData, err := h.podmanClient.ContainerInspect(h.driver.ctx, h.containerID)
-				h.stateLock.Lock()
-				h.completedAt = time.Now()
-				if err != nil {
-					h.exitResult.Err = fmt.Errorf("Driver was unable to get the exit code. %s: %w", h.containerID, err)
-					h.logger.Error("Failed to inspect stopped container, can not get exit code", "container", h.containerID, "error", err)
-					h.exitResult.Signal = 0
-				} else {
-					h.exitResult.ExitCode = int(inspectData.State.ExitCode)
-					if len(inspectData.State.Error) > 0 {
-						h.exitResult.Err = errors.New(inspectData.State.Error)
-						h.logger.Error("Container error", "container", h.containerID, "error", h.exitResult.Err)
-					}
-					h.completedAt = inspectData.State.FinishedAt
-					if inspectData.State.OOMKilled {
-						h.exitResult.OOMKilled = true
-						h.exitResult.Err = fmt.Errorf("Podman container killed by OOM killer")
-						h.logger.Error("Podman container killed by OOM killer", "container", h.containerID)
-					}
-				}
+		if !h.isRunning() {
+			return
+		}
 
-				h.procState = drivers.TaskStateExited
-				h.stateLock.Unlock()
+		containerStats, statsErr := client.ContainerStats(ctx, h.containerID)
+		if statsErr != nil {
+			h.logger.Debug("Could not get container stats", "container", h.containerID, "error", statsErr)
+			if ctx.Err() != nil {
 				return
 			}
-			// continue and wait for next cycle, it should eventually
-			// fall into the "TaskStateExited" case
-			h.logger.Debug("Could not get container stats, unknown error", "error", fmt.Sprintf("%#v", statsErr))
 			continue
 		}
 
@@ -252,4 +244,89 @@ func (h *TaskHandle) runContainerMonitor() {
 		h.containerStats = containerStats
 		h.stateLock.Unlock()
 	}
+}
+
+func (h *TaskHandle) runContainerMonitor() {
+	h.runContainerMonitorWithClient(h.driver.ctx, h.podmanClient, containerMonitorRetryInterval)
+}
+
+func (h *TaskHandle) runContainerMonitorWithClient(ctx context.Context, client containerLifecycleClient, retryInterval time.Duration) {
+	h.logger.Debug("Monitoring container lifecycle", "container", h.containerID)
+
+	for h.isRunning() {
+		waitErr := client.ContainerWait(ctx, h.containerID, []string{"exited"})
+		if ctx.Err() != nil {
+			return
+		}
+
+		inspectData, inspectErr := client.ContainerInspect(ctx, h.containerID)
+		switch {
+		case inspectErr == nil && containerExited(inspectData.State):
+			h.markContainerExited(inspectData, nil)
+			return
+		case errors.Is(inspectErr, api.ContainerNotFound):
+			h.markContainerExited(api.InspectContainerData{}, inspectErr)
+			return
+		case inspectErr == nil:
+			h.logger.Warn("Container wait returned while container is not exited", "container", h.containerID, "state", inspectData.State, "error", waitErr)
+		default:
+			h.logger.Warn("Could not reconcile container after wait returned", "container", h.containerID, "wait_error", waitErr, "inspect_error", inspectErr)
+		}
+
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func containerExited(state *api.InspectContainerState) bool {
+	if state == nil || state.Running || state.Paused {
+		return false
+	}
+
+	switch state.Status {
+	case "exited", "stopped":
+		return true
+	default:
+		return state.Dead
+	}
+}
+
+func (h *TaskHandle) markContainerExited(inspectData api.InspectContainerData, inspectErr error) {
+	h.stateLock.Lock()
+	defer h.stateLock.Unlock()
+
+	if h.procState == drivers.TaskStateExited {
+		return
+	}
+
+	h.completedAt = time.Now()
+	if inspectErr != nil {
+		h.exitResult.Err = fmt.Errorf("Driver was unable to get the exit code. %s: %w", h.containerID, inspectErr)
+		h.logger.Error("Failed to inspect stopped container, can not get exit code", "container", h.containerID, "error", inspectErr)
+		h.exitResult.Signal = 0
+	} else if inspectData.State != nil {
+		h.exitResult.ExitCode = int(inspectData.State.ExitCode)
+		if inspectData.State.Error != "" {
+			h.exitResult.Err = errors.New(inspectData.State.Error)
+			h.logger.Error("Container error", "container", h.containerID, "error", h.exitResult.Err)
+		}
+		if !inspectData.State.FinishedAt.IsZero() {
+			h.completedAt = inspectData.State.FinishedAt
+		}
+		if inspectData.State.OOMKilled {
+			h.exitResult.OOMKilled = true
+			h.exitResult.Err = errors.New("Podman container killed by OOM killer")
+			h.logger.Error("Podman container killed by OOM killer", "container", h.containerID)
+		}
+	} else {
+		h.exitResult.Err = fmt.Errorf("Driver was unable to get the exit code. %s: inspect response has no state", h.containerID)
+		h.logger.Error("Stopped container inspect response has no state", "container", h.containerID)
+	}
+
+	h.procState = drivers.TaskStateExited
 }

--- a/handle_test.go
+++ b/handle_test.go
@@ -1,0 +1,218 @@
+// Copyright IBM Corp. 2019, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-podman/api"
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+type lifecycleStep struct {
+	waitErr    error
+	inspect    api.InspectContainerData
+	inspectErr error
+}
+
+type fakeLifecycleClient struct {
+	mu           sync.Mutex
+	steps        []lifecycleStep
+	waitCalls    int
+	inspectCalls int
+}
+
+type fakeStatsClient struct {
+	cancel context.CancelFunc
+	err    error
+	calls  int
+}
+
+func (f *fakeStatsClient) ContainerStats(context.Context, string) (api.Stats, error) {
+	f.calls++
+	if f.cancel != nil {
+		f.cancel()
+	}
+	return api.Stats{}, f.err
+}
+
+func (f *fakeLifecycleClient) ContainerWait(ctx context.Context, _ string, _ []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.waitCalls >= len(f.steps) {
+		return errors.New("unexpected wait call")
+	}
+	err := f.steps[f.waitCalls].waitErr
+	f.waitCalls++
+	return err
+}
+
+func (f *fakeLifecycleClient) ContainerInspect(context.Context, string) (api.InspectContainerData, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.inspectCalls >= len(f.steps) {
+		return api.InspectContainerData{}, errors.New("unexpected inspect call")
+	}
+	step := f.steps[f.inspectCalls]
+	f.inspectCalls++
+	return step.inspect, step.inspectErr
+}
+
+func (f *fakeLifecycleClient) calls() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.waitCalls, f.inspectCalls
+}
+
+func newLifecycleTestHandle() *TaskHandle {
+	return &TaskHandle{
+		containerID: "container-id",
+		logger:      hclog.NewNullLogger(),
+		taskConfig:  &drivers.TaskConfig{ID: "task-id", Name: "task"},
+		procState:   drivers.TaskStateRunning,
+		exitResult:  &drivers.ExitResult{},
+	}
+}
+
+func TestContainerMonitorRecordsExitedContainer(t *testing.T) {
+	finishedAt := time.Date(2026, time.August, 26, 17, 0, 0, 0, time.UTC)
+	client := &fakeLifecycleClient{steps: []lifecycleStep{{
+		inspect: api.InspectContainerData{State: &api.InspectContainerState{
+			Status:     "exited",
+			ExitCode:   23,
+			FinishedAt: finishedAt,
+		}},
+	}}}
+	handle := newLifecycleTestHandle()
+
+	handle.runContainerMonitorWithClient(context.Background(), client, 0)
+
+	status := handle.taskStatus()
+	if status.State != drivers.TaskStateExited {
+		t.Fatalf("state = %q; want exited", status.State)
+	}
+	if status.ExitResult.ExitCode != 23 {
+		t.Fatalf("exit code = %d; want 23", status.ExitResult.ExitCode)
+	}
+	if !status.CompletedAt.Equal(finishedAt) {
+		t.Fatalf("completed at = %s; want %s", status.CompletedAt, finishedAt)
+	}
+}
+
+func TestContainerMonitorReconcilesAfterWaitFailure(t *testing.T) {
+	waitErr := errors.New("event stream disconnected")
+	client := &fakeLifecycleClient{steps: []lifecycleStep{
+		{
+			waitErr: waitErr,
+			inspect: api.InspectContainerData{State: &api.InspectContainerState{
+				Status:  "running",
+				Running: true,
+			}},
+		},
+		{
+			inspect: api.InspectContainerData{State: &api.InspectContainerState{
+				Status:   "exited",
+				ExitCode: 7,
+			}},
+		},
+	}}
+	handle := newLifecycleTestHandle()
+
+	handle.runContainerMonitorWithClient(context.Background(), client, 0)
+
+	waitCalls, inspectCalls := client.calls()
+	if waitCalls != 2 || inspectCalls != 2 {
+		t.Fatalf("calls = wait:%d inspect:%d; want wait:2 inspect:2", waitCalls, inspectCalls)
+	}
+	status := handle.taskStatus()
+	if status.State != drivers.TaskStateExited || status.ExitResult.ExitCode != 7 {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestContainerMonitorFindsExitAfterWaitFailure(t *testing.T) {
+	client := &fakeLifecycleClient{steps: []lifecycleStep{{
+		waitErr: errors.New("wait request raced with container exit"),
+		inspect: api.InspectContainerData{State: &api.InspectContainerState{
+			Status:   "exited",
+			ExitCode: 42,
+		}},
+	}}}
+	handle := newLifecycleTestHandle()
+
+	handle.runContainerMonitorWithClient(context.Background(), client, 0)
+
+	waitCalls, inspectCalls := client.calls()
+	if waitCalls != 1 || inspectCalls != 1 {
+		t.Fatalf("calls = wait:%d inspect:%d; want wait:1 inspect:1", waitCalls, inspectCalls)
+	}
+	status := handle.taskStatus()
+	if status.State != drivers.TaskStateExited || status.ExitResult.ExitCode != 42 {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestContainerExited(t *testing.T) {
+	testCases := []struct {
+		name  string
+		state *api.InspectContainerState
+		want  bool
+	}{
+		{name: "nil state"},
+		{name: "running", state: &api.InspectContainerState{Status: "running", Running: true}},
+		{name: "paused", state: &api.InspectContainerState{Status: "paused", Paused: true}},
+		{name: "created", state: &api.InspectContainerState{Status: "created"}},
+		{name: "exited", state: &api.InspectContainerState{Status: "exited"}, want: true},
+		{name: "stopped", state: &api.InspectContainerState{Status: "stopped"}, want: true},
+		{name: "dead", state: &api.InspectContainerState{Status: "unknown", Dead: true}, want: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := containerExited(tc.state); got != tc.want {
+				t.Fatalf("containerExited() = %t; want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatsMonitorDoesNotUseStatsErrorsAsLifecycleEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &fakeStatsClient{
+		cancel: cancel,
+		err:    api.ContainerWrongState,
+	}
+	handle := newLifecycleTestHandle()
+
+	handle.runStatsMonitorWithClient(ctx, client, 0)
+
+	if client.calls != 1 {
+		t.Fatalf("stats calls = %d; want 1", client.calls)
+	}
+	if !handle.isRunning() {
+		t.Fatal("stats error changed task lifecycle state")
+	}
+}
+
+func TestContainerMonitorStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client := &fakeLifecycleClient{steps: []lifecycleStep{{waitErr: context.Canceled}}}
+	handle := newLifecycleTestHandle()
+
+	handle.runContainerMonitorWithClient(ctx, client, 0)
+
+	waitCalls, inspectCalls := client.calls()
+	if waitCalls != 1 || inspectCalls != 0 {
+		t.Fatalf("calls = wait:%d inspect:%d; want wait:1 inspect:0", waitCalls, inspectCalls)
+	}
+	if !handle.isRunning() {
+		t.Fatal("canceled monitor changed task state")
+	}
+}


### PR DESCRIPTION
## Summary

- use Podman's container wait endpoint as the source of truth for task exit
- keep container stats polling responsible only for resource metrics
- inspect the container whenever wait returns, including after a wait error
- reconnect the wait request when inspect still reports a non-terminal state
- use the no-timeout streaming HTTP client for blocking wait requests
- stop stats emission when the task exits

## Motivation

The current container monitor infers task exit from the per-container stats response. This couples lifecycle detection to a metrics endpoint whose stopped-container behavior has changed across Podman releases (#182, #277).

This change follows the lifecycle/metrics separation proposed by #80, but uses a per-container `wait?condition=exited` request instead of a global event stream. A wait request can be re-established after a transport failure, and inspect provides reconciliation if the request races with a short-lived container exit.

Stats errors no longer change task lifecycle state. Stats polling also waits for the first collection interval, giving the lifecycle monitor a chance to finalize containers that exit before the first metrics sample.

```mermaid
sequenceDiagram
    participant D as Nomad Podman driver
    participant W as Podman wait API
    participant S as Podman stats API
    participant I as Podman inspect API

    par Lifecycle
        D->>W: wait(condition=exited)
        W-->>D: exited or transport error
        D->>I: inspect container
        I-->>D: terminal state and exit code
        D->>D: finalize task
    and Metrics
        D->>S: stats(stream=false)
        S-->>D: metrics or error
        Note over D,S: Never changes task lifecycle state
    end
```

## Failure handling

- If wait returns and inspect reports `exited`, `stopped`, or `dead`, the task is finalized from inspect data.
- If inspect reports that the container is still active, wait is retried after a short delay.
- If wait fails after the container has already exited, inspect still finalizes the task.
- If the container no longer exists, the existing unknown-exit-code behavior is preserved.
- Driver shutdown cancels the blocking wait request through its context.

## Tests

- `go test ./... -run '^(TestContainerWait|TestContainerMonitor|TestContainerExited|TestStatsMonitor)' -count=1`
- `go test -race . -run '^(TestContainerMonitor|TestContainerExited|TestStatsMonitor)' -count=1`
- `go vet ./...`

Full Podman integration tests were not run locally because this environment does not have access to a Podman service socket. The existing GitHub Actions job provides the Podman-backed test environment.

Related: #80, #277, #278
